### PR TITLE
Relocate .specs scaffolding and document agent asset workflows

### DIFF
--- a/.github/workflows/scripts/create-release-packages.sh
+++ b/.github/workflows/scripts/create-release-packages.sh
@@ -32,9 +32,12 @@ rm -rf "$GENRELEASES_DIR"/* || true
 
 rewrite_paths() {
   sed -E \
-    -e 's@(/?)memory/@.specify/memory/@g' \
-    -e 's@(/?)scripts/@.specify/scripts/@g' \
-    -e 's@(/?)templates/@.specify/templates/@g'
+  -e 's@\\.specs/memory/@.specs/.specify/memory/@g' \
+  -e 's@\\.specs/scripts/@.specs/.specify/scripts/@g' \
+  -e 's@\\.specs/templates/@.specs/.specify/templates/@g' \
+  -e 's@(^|[^[:alnum:]_/])memory/@\1.specs/.specify/memory/@g' \
+  -e 's@(^|[^[:alnum:]_/])scripts/@\1.specs/.specify/scripts/@g' \
+  -e 's@(^|[^[:alnum:]_/])templates/@\1.specs/.specify/templates/@g'
 }
 
 generate_commands() {
@@ -90,38 +93,48 @@ build_variant() {
   mkdir -p "$base_dir"
   
   # Copy base structure but filter scripts by variant
-  SPEC_DIR="$base_dir/.specify"
-  mkdir -p "$SPEC_DIR"
+  SPEC_DIR="$base_dir/.specs"
+  SPECIFY_DIR="$SPEC_DIR/.specify"
+  mkdir -p "$SPECIFY_DIR"
   
-  [[ -d memory ]] && { cp -r memory "$SPEC_DIR/"; echo "Copied memory -> .specify"; }
+  [[ -d memory ]] && { cp -r memory "$SPECIFY_DIR/"; echo "Copied memory -> .specs/.specify"; }
+  [[ -d plan ]] && { cp -r plan "$SPECIFY_DIR/"; echo "Copied plan -> .specs/.specify"; }
+  [[ -d spec ]] && { cp -r spec "$SPECIFY_DIR/"; echo "Copied spec -> .specs/.specify"; }
+  [[ -d notes ]] && { cp -r notes "$SPECIFY_DIR/"; echo "Copied notes -> .specs/.specify"; }
+  [[ -d scratch ]] && { cp -r scratch "$SPECIFY_DIR/"; echo "Copied scratch -> .specs/.specify"; }
+  [[ -d docs ]] && { cp -r docs "$SPECIFY_DIR/"; echo "Copied docs -> .specs/.specify"; }
+  [[ -d logs ]] && { cp -r logs "$SPECIFY_DIR/"; echo "Copied logs -> .specs/.specify"; }
+  [[ -d specs ]] && { cp -r specs "$SPECIFY_DIR/"; echo "Copied specs -> .specs/.specify"; }
   
   # Only copy the relevant script variant directory
   if [[ -d scripts ]]; then
-    mkdir -p "$SPEC_DIR/scripts"
+    mkdir -p "$SPECIFY_DIR/scripts"
     case $script in
       sh)
-        [[ -d scripts/bash ]] && { cp -r scripts/bash "$SPEC_DIR/scripts/"; echo "Copied scripts/bash -> .specify/scripts"; }
+        [[ -d scripts/bash ]] && { cp -r scripts/bash "$SPECIFY_DIR/scripts/"; echo "Copied scripts/bash -> .specs/.specify/scripts"; }
         # Copy any script files that aren't in variant-specific directories
-        find scripts -maxdepth 1 -type f -exec cp {} "$SPEC_DIR/scripts/" \; 2>/dev/null || true
+        find scripts -maxdepth 1 -type f -exec cp {} "$SPECIFY_DIR/scripts/" \; 2>/dev/null || true
         ;;
       ps)
-        [[ -d scripts/powershell ]] && { cp -r scripts/powershell "$SPEC_DIR/scripts/"; echo "Copied scripts/powershell -> .specify/scripts"; }
+        [[ -d scripts/powershell ]] && { cp -r scripts/powershell "$SPECIFY_DIR/scripts/"; echo "Copied scripts/powershell -> .specs/.specify/scripts"; }
         # Copy any script files that aren't in variant-specific directories
-        find scripts -maxdepth 1 -type f -exec cp {} "$SPEC_DIR/scripts/" \; 2>/dev/null || true
+        find scripts -maxdepth 1 -type f -exec cp {} "$SPECIFY_DIR/scripts/" \; 2>/dev/null || true
         ;;
     esac
   fi
   
-  [[ -d templates ]] && { mkdir -p "$SPEC_DIR/templates"; find templates -type f -not -path "templates/commands/*" -exec cp --parents {} "$SPEC_DIR"/ \; ; echo "Copied templates -> .specify/templates"; }
-  # Inject variant into plan-template.md within .specify/templates if present
-  local plan_tpl="$base_dir/.specify/templates/plan-template.md"
+  [[ -d templates ]] && { mkdir -p "$SPECIFY_DIR/templates"; find templates -type f -not -path "templates/commands/*" -exec cp --parents {} "$SPECIFY_DIR"/ \; ; echo "Copied templates -> .specs/.specify/templates"; }
+  # Inject variant into plan-template.md within .specs/.specify/templates if present
+  local plan_tpl="$base_dir/.specs/.specify/templates/plan-template.md"
   if [[ -f "$plan_tpl" ]]; then
     plan_norm=$(tr -d '\r' < "$plan_tpl")
     # Extract script command from YAML frontmatter
     script_command=$(printf '%s\n' "$plan_norm" | awk -v sv="$script" '/^[[:space:]]*'"$script"':[[:space:]]*/ {sub(/^[[:space:]]*'"$script"':[[:space:]]*/, ""); print; exit}')
     if [[ -n $script_command ]]; then
-      # Always prefix with .specify/ for plan usage
-      script_command=".specify/$script_command"
+      if [[ $script_command != .specs/* ]]; then
+        # Always prefix with .specs/.specify/ for plan usage when missing
+        script_command=".specs/.specify/$script_command"
+      fi
       # Replace {SCRIPT} placeholder with the script command and __AGENT__ with agent name
       substituted=$(sed "s|{SCRIPT}|${script_command}|g" "$plan_tpl" | tr -d '\r' | sed "s|__AGENT__|${agent}|g")
       # Strip YAML frontmatter from plan template output (keep body only)
@@ -189,13 +202,13 @@ norm_list() {
 
 validate_subset() {
   local type=$1; shift; local -n allowed=$1; shift; local items=("$@")
-  local ok=1
+  local ok=0
   for it in "${items[@]}"; do
     local found=0
     for a in "${allowed[@]}"; do [[ $it == "$a" ]] && { found=1; break; }; done
     if [[ $found -eq 0 ]]; then
       echo "Error: unknown $type '$it' (allowed: ${allowed[*]})" >&2
-      ok=0
+      ok=1
     fi
   done
   return $ok

--- a/.github/workflows/scripts/create-release-packages.sh
+++ b/.github/workflows/scripts/create-release-packages.sh
@@ -202,16 +202,16 @@ norm_list() {
 
 validate_subset() {
   local type=$1; shift; local -n allowed=$1; shift; local items=("$@")
-  local ok=0
+  local errors=0
   for it in "${items[@]}"; do
     local found=0
     for a in "${allowed[@]}"; do [[ $it == "$a" ]] && { found=1; break; }; done
     if [[ $found -eq 0 ]]; then
       echo "Error: unknown $type '$it' (allowed: ${allowed[*]})" >&2
-      ok=1
+      errors=1
     fi
   done
-  return $ok
+  return $errors
 }
 
 if [[ -n ${AGENTS:-} ]]; then

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ env/
 .env
 .env.local
 *.lock
+.specs/
 
 # Spec Kit-specific files
 .genreleases/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ All notable changes to the Specify CLI will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.19] - 2025-09-24
+
+### Added
+
+- `--template-repo` CLI option (and `SPEC_KIT_TEMPLATE_REPO`) to pull release assets from a fork or alternate repository.
+- `--template-path` CLI option (and `SPEC_KIT_TEMPLATE_PATH`) to scaffold directly from a local template ZIP or directory without hitting GitHub.
+
+### Changed
+
+- Template download/extraction pipeline now honors local overrides while preserving `.specs/.specify` relocation and tracker output.
+
+## [0.0.18] - 2025-09-24
+
+### Changed
+
+- Consolidated all non-agent project assets under a new `/.specs/.specify` hierarchy while keeping agent folders at the repository root for IDE autodiscovery.
+- Updated the Specify CLI, packaging scripts, shell/PowerShell helpers, and command templates to reference the relocated directories.
+- Added migration logic and legacy fallbacks so existing projects using `.specify/` or top-level `specs/` continue to function.
+
 ## [0.0.17] - 2025-09-22
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ When working on spec-kit:
 1. Test changes with the `specify` CLI commands (`/specify`, `/plan`, `/tasks`) in your coding agent of choice
 2. Verify templates are working correctly in `templates/` directory
 3. Test script functionality in the `scripts/` directory
-4. Ensure memory files (`memory/constitution.md`) are updated if major process changes are made
+4. Ensure memory files (`/.specs/.specify/memory/constitution.md`) are updated if major process changes are made
 
 ## AI contributions in Spec Kit
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ The `specify` command supports the following options:
 | `--skip-tls`           | Flag     | Skip SSL/TLS verification (not recommended)                                 |
 | `--debug`              | Flag     | Enable detailed debug output for troubleshooting                            |
 | `--github-token`       | Option   | GitHub token for API requests (or set GH_TOKEN/GITHUB_TOKEN env variable)  |
+| `--template-repo`      | Option   | Override the template release source (`owner/repo`). Defaults to `github/spec-kit` or `SPEC_KIT_TEMPLATE_REPO`. |
+| `--template-path`      | Option   | Use a local template ZIP or directory instead of downloading. Mirrors `SPEC_KIT_TEMPLATE_PATH`. |
 
 ### Examples
 
@@ -191,6 +193,9 @@ specify init my-project --ai gemini --no-git
 # Enable debug output for troubleshooting
 specify init my-project --ai claude --debug
 
+# Bootstrap from a local template archive
+specify init my-project --template-path ./builds/spec-kit-template-copilot-sh.zip
+
 # Use GitHub token for API requests (helpful for corporate environments)
 specify init my-project --ai claude --github-token ghp_your_token_here
 
@@ -216,7 +221,9 @@ After running `specify init`, your AI coding agent will have access to these sla
 
 | Variable         | Description                                                                                    |
 |------------------|------------------------------------------------------------------------------------------------|
-| `SPECIFY_FEATURE` | Override feature detection for non-Git repositories. Set to the feature directory name (e.g., `001-photo-albums`) to work on a specific feature when not using Git branches.<br/>**Must be set in the context of the agent you're working with prior to using `/plan` or follow-up commands. |
+| `SPECIFY_FEATURE`        | Override feature detection for non-Git repositories. Set to the feature directory name (e.g., `001-photo-albums`) to work on a specific feature when not using Git branches.<br/>**Must be set in the context of the agent you're working with prior to using `/plan` or follow-up commands. |
+| `SPEC_KIT_TEMPLATE_REPO` | Alternative template repository in `owner/repo` form. Takes the same value as `--template-repo`. |
+| `SPEC_KIT_TEMPLATE_PATH` | Absolute or relative path to a local template ZIP or directory. Takes the same value as `--template-path`. |
 
 ## 📚 Core philosophy
 
@@ -337,7 +344,7 @@ The first step should be establishing your project's governing principles using 
 /constitution Create principles focused on code quality, testing standards, user experience consistency, and performance requirements. Include governance for how these principles should guide technical decisions and implementation choices.
 ```
 
-This step creates or updates the `/memory/constitution.md` file with your project's foundational guidelines that the AI agent will reference during specification, planning, and implementation phases.
+This step creates or updates the `/.specs/.specify/memory/constitution.md` file with your project's foundational guidelines that the AI agent will reference during specification, planning, and implementation phases.
 
 ### **STEP 2:** Create project specifications
 
@@ -369,7 +376,7 @@ delete any comments that you made, but you can't delete comments anybody else ma
 
 After this prompt is entered, you should see Claude Code kick off the planning and spec drafting process. Claude Code will also trigger some of the built-in scripts to set up the repository.
 
-Once this step is completed, you should have a new branch created (e.g., `001-create-taskify`), as well as a new specification in the `specs/001-create-taskify` directory.
+Once this step is completed, you should have a new branch created (e.g., `001-create-taskify`), as well as a new specification in the `.specs/.specify/specs/001-create-taskify` directory.
 
 The produced specification should contain a set of user stories and functional requirements, as defined in the template.
 
@@ -505,7 +512,7 @@ This helps refine the implementation plan and helps you avoid potential blind sp
 You can also ask Claude Code (if you have the [GitHub CLI](https://docs.github.com/en/github-cli/github-cli) installed) to go ahead and create a pull request from your current branch to `main` with a detailed description, to make sure that the effort is properly tracked.
 
 >[!NOTE]
->Before you have the agent implement it, it's also worth prompting Claude Code to cross-check the details to see if there are any over-engineered pieces (remember - it can be over-eager). If over-engineered components or decisions exist, you can ask Claude Code to resolve them. Ensure that Claude Code follows the [constitution](base/memory/constitution.md) as the foundational piece that it must adhere to when establishing the plan.
+>Before you have the agent implement it, it's also worth prompting Claude Code to cross-check the details to see if there are any over-engineered pieces (remember - it can be over-eager). If over-engineered components or decisions exist, you can ask Claude Code to resolve them. Ensure that Claude Code follows the [constitution](base/.specs/.specify/memory/constitution.md) as the foundational piece that it must adhere to when establishing the plan.
 
 ### STEP 6: Implementation
 

--- a/docs/agent-assets.md
+++ b/docs/agent-assets.md
@@ -1,0 +1,74 @@
+# Agent Asset Packaging
+
+This guide explains how Spec Kit assembles the command prompts and supporting files that ship with each AI agent bundle. Use it when you need to trace where the prompts come from, verify the new `.specs/.specify` layout, or build custom packages for downstream consumers.
+
+## Overview
+
+Each agent receives a curated slice of the repository that includes:
+
+- **Command prompts** sourced from `templates/commands/*.md`, rewritten into the agent-specific format (`.md`, `.prompt.md`, or `.toml`).
+- **Shared templates** (`plan-template.md`, `tasks-template.md`, `spec-template.md`, `agent-file-template.md`) and supporting documentation copied into `.specs/.specify/templates/` and `.specs/.specify/docs/`.
+- **Automation scripts** copied into `.specs/.specify/scripts/<shell>/`, matching the `--script` variant selected during packaging (Bash or PowerShell).
+- **Project memory and supporting assets** relocated under `.specs/.specify/` to keep non-agent files together.
+
+The packaging workflow guarantees that every generated archive adheres to the consolidated `.specs/.specify` directory structure introduced in v0.0.18.
+
+## Source of Agent Templates
+
+| Asset type                    | Source path (repo)                | Destination in package                |
+|-------------------------------|-----------------------------------|---------------------------------------|
+| Command prompts               | `templates/commands/*.md`         | `.<agent>/commands/` (format dependent)|
+| Agent context template        | `templates/agent-file-template.md`| `.specs/.specify/templates/`          |
+| Specification + plan templates| `templates/spec-template.md`, `templates/plan-template.md`, `templates/tasks-template.md` | `.specs/.specify/templates/` |
+| Automation scripts            | `scripts/bash/`, `scripts/powershell/` | `.specs/.specify/scripts/bash/` or `.specs/.specify/scripts/powershell/` |
+| Constitution (memory)         | `memory/constitution.md`          | `.specs/.specify/memory/constitution.md` |
+| Docs                          | `docs/`                           | `.specs/.specify/docs/`               |
+
+The original prompt templates still reference placeholder paths such as `scripts/bash/...` or `/memory/constitution.md`. During packaging these references are rewritten to `.specs/.specify/...` so the generated projects align with the new hierarchy without modifying the authoring files in-place.
+
+## Packaging Workflow
+
+The script `.github/workflows/scripts/create-release-packages.sh` drives asset creation for every supported agent. Key steps:
+
+1. **Determine agent/script variants** – reads `ALL_AGENTS` and `ALL_SCRIPTS`, optionally filtered by the `AGENTS` or `SCRIPTS` environment variables.
+2. **Copy shared assets** – creates `.specs/.specify/` inside the build directory and copies docs, memory, scripts, and templates.
+3. **Normalize paths** – runs `rewrite_paths()` to replace legacy references (`memory/`, `scripts/`, `templates/`) with `.specs/.specify/...` inside each command prompt so the generated instructions point at the relocated files.
+4. **Generate prompts** – `generate_commands()` converts every file in `templates/commands/` into the agent’s preferred format (Markdown, `prompt.md`, or TOML) and drops them into `.<agent>/commands/` (or equivalent).
+5. **Zip the package** – produces archives named `spec-kit-template-<agent>-<script>-<version>.zip` inside `.genreleases/`.
+
+The same script is invoked locally or by CI workflows. Because it produces a plain directory before zipping, you can inspect the build output (for example `.genreleases/sdd-claude-package-sh/`) prior to compression.
+
+## Using Packaged Templates
+
+The `specify` CLI downloads these archives by default from the `github/spec-kit` releases. You can direct the CLI to alternate sources using:
+
+- `--template-repo owner/repo` or `SPEC_KIT_TEMPLATE_REPO` to pull from a forked release.
+- `--template-path /path/to/template.zip` or `SPEC_KIT_TEMPLATE_PATH` to scaffold from a local archive or directory (handy when testing output from `.genreleases/`).
+
+Regardless of the source, the CLI relocates any legacy `.specify/` content into `.specs/.specify/` and ensures scripts are executable, so existing customized archives remain compatible.
+
+## Verifying a Package Locally
+
+To confirm an archive produces the expected structure:
+
+```bash
+AGENTS=claude SCRIPTS=sh bash .github/workflows/scripts/create-release-packages.sh v0.0.19
+uv run specify init tmp/claude-demo \
+  --ai claude \
+  --script sh \
+  --template-path .genreleases/spec-kit-template-claude-sh-v0.0.19.zip \
+  --no-git
+```
+
+Inspect `tmp/claude-demo/.specs/.specify/` and `tmp/claude-demo/.claude/commands/` to ensure prompts reference the new paths.
+
+## Adding or Updating Agents
+
+When bringing a new agent online (or modifying an existing one):
+
+1. Update `templates/commands/*.md` with any agent-specific guidance.
+2. Extend the packaging script’s `ALL_AGENTS` list and case statement to define the target directory (for example `.windsurf/workflows/`).
+3. Regenerate a package and run `specify init` with `--template-path` to validate the resulting scaffold.
+4. Publish the new archive via the release workflow or distribute it internally.
+
+See `AGENTS.md` for a complete checklist when integrating additional agents into the toolkit.

--- a/docs/custom-agent-assets.md
+++ b/docs/custom-agent-assets.md
@@ -1,0 +1,140 @@
+# Building Custom Agent Asset Bundles
+
+This guide walks through every step required to create, package, and distribute a new agent bundle that works seamlessly with Spec Kit’s `.specs/.specify` project layout. Follow these instructions whenever you need to onboard a new AI assistant or fork existing prompts for internal use.
+
+## Prerequisites
+
+- Working checkout of the Spec Kit repository (or a fork).
+- Python environment capable of running `uv run specify` (Python 3.11+).
+- Bash or PowerShell available locally (the packaging script is POSIX shell).
+- `zip` CLI installed (required for archive generation).
+- Familiarity with Markdown and, if needed, TOML formatting.
+
+## 1. Author or Customize Command Prompts
+
+1. Navigate to `templates/commands/`.
+2. Duplicate an existing command file (e.g., `plan.md`) or create a new one.
+3. Update the narrative for your agent. You can:
+   - Adjust instructions to suit different slash command UX.
+   - Add agent-specific warnings or prerequisites.
+4. Keep placeholder tokens intact:
+   - `{SCRIPT}` for the helper script path that will be injected per shell variant.
+   - `$ARGUMENTS` (Markdown) or `{{args}}` (TOML) for the agent’s input string.
+   - Path references should use the legacy structure (`scripts/...`, `/memory/...`); the packaging step rewrites them to `.specs/.specify/...` for you.
+
+> **Tip:** Use `templates/commands/*` as the canonical source of truth. Do not edit the generated prompts inside `.genreleases/` or scaffolded projects; those will be overwritten next time you run the packaging script.
+
+## 2. Register the Agent in the Packaging Script
+
+Edit `.github/workflows/scripts/create-release-packages.sh`:
+
+1. Add your agent key to the `ALL_AGENTS` array (e.g., `myagent`).
+2. Extend the `case` statement in `build_variant()` to define the output directory. For example:
+
+   ```bash
+   myagent)
+     mkdir -p "$base_dir/.myagent/prompts"
+     generate_commands myagent md "\$ARGUMENTS" "$base_dir/.myagent/prompts" "$script" ;;
+   ```
+
+3. If your agent requires supplemental files (e.g., `.myagent/config.json`), copy them in this block.
+4. Leave the rest of the script untouched so that common assets (
+   `memory/`, `docs/`, `scripts/`, `templates/`) are copied into `.specs/.specify/` automatically.
+
+The helper functions will:
+
+- Copy shared templates and scripts into the new hierarchy.
+- Rewrite prompt paths using `rewrite_paths()` so references point at `.specs/.specify/...`.
+- Format prompts to `.md`, `.prompt.md`, or `.toml` depending on your `generate_commands` configuration.
+
+## 3. Generate the Package Locally
+
+Use environment variables to target only your agent while you iterate:
+
+```bash
+AGENTS=myagent SCRIPTS=sh bash .github/workflows/scripts/create-release-packages.sh v0.0.1-myagent
+```
+
+This produces two outputs:
+
+- `.genreleases/sdd-myagent-package-sh/` – folder containing the staged assets.
+- `.genreleases/spec-kit-template-myagent-sh-v0.0.1-myagent.zip` – archive ready for distribution.
+
+Inspect the directory before shipping:
+
+```bash
+find .genreleases/sdd-myagent-package-sh -maxdepth 2 -type d
+unzip -l .genreleases/spec-kit-template-myagent-sh-v0.0.1-myagent.zip | head
+```
+
+Ensure you see:
+
+- `.specs/.specify/templates/…`
+- `.specs/.specify/scripts/<shell>/…`
+- `.myagent/prompts/…` (or whatever directory you configured)
+
+## 4. Smoke-Test with the CLI
+
+Run `specify init` against your freshly built archive:
+
+```bash
+uv run specify init tmp/myagent-demo \
+  --ai myagent \
+  --script sh \
+  --template-path .genreleases/spec-kit-template-myagent-sh-v0.0.1-myagent.zip \
+  --no-git
+```
+
+Verify that:
+
+- Non-agent assets land in `.specs/.specify/`.
+- Every generated prompt references `.specs/.specify/...` paths.
+- Shell scripts in `.specs/.specify/scripts/bash/` are executable.
+
+If something looks off, tweak the command templates or packaging script and rerun the steps above.
+
+## 5. (Optional) Teach the CLI About Your Agent
+
+To expose the agent in `specify --help` and enable `--ai myagent`:
+
+1. Edit `src/specify_cli/__init__.py`:
+   - Add the display name to `AI_CHOICES`.
+   - Update `agent_folder_map` if you need custom security notices.
+2. If the agent needs extra behavior (e.g., custom prompts for warnings), extend the CLI logic where we set up agent-specific cases.
+
+This step is optional if you only plan to pass `--template-path` manually, but it keeps UX consistent.
+
+## 6. Distribute the Bundle
+
+You have multiple deployment options:
+
+- **Local testing**: share the zip with teammates; they call `specify init --template-path /path/to/archive.zip`.
+- **GitHub release**: upload the archive to a GitHub release (your fork or a private repo) and run the CLI with `--template-repo owner/repo` (matching the release naming convention).
+- **CI pipeline**: run `.github/workflows/scripts/create-release-packages.sh` in your pipeline, publish the artifacts to your preferred storage, and update automation to download them before running `specify init`.
+
+Regardless of the delivery channel, the CLI will still relocate any legacy `.specify/` assets into `.specs/.specify/` when the project is initialized.
+
+## 7. Keep Docs & Governance Updated
+
+If your new agent introduces different workflows or requires special setup, update:
+
+- `docs/agent-assets.md` – high-level overview of available bundles.
+- The README or installation guide if users need additional dependencies.
+- `AGENTS.md` (or your own fork’s equivalent) so maintainers know the integration steps you followed.
+
+## Troubleshooting Checklist
+
+| Problem | Likely Cause | Fix |
+|---------|--------------|-----|
+| Generated prompts still refer to `scripts/` or `/memory/` | `rewrite_paths()` did not match your format | Ensure your templates use the legacy paths exactly (`scripts/...`, `memory/...`), or extend `rewrite_paths()` if your prompts need additional substitutions |
+| CLI can’t find your agent | Agent missing from `AI_CHOICES` in the CLI or the `--ai` flag wasn’t supplied | Add the agent to the CLI or call `specify init` with `--template-path` instead |
+| Archive missing `.specs/.specify/` directories | Packaging script changes prevented the shared copy step | Double-check you didn’t override the base copy logic in `build_variant()` |
+| Archive command errors about `zip` | `zip` utility not installed | `sudo apt-get install -y zip` (WSL/Ubuntu) |
+
+## Next Steps
+
+- Automate packaging in CI so every release publishes your agent’s archive.
+- Create tests that run `specify init` with your bundle and validate the resulting filesystem tree.
+- Share the archive with your agent users; include the `--template-path` instructions in onboarding docs.
+
+With these steps you can iterate on prompts safely, keep assets aligned with the `.specs/.specify` hierarchy, and deliver a polished experience for any custom agent.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -49,6 +49,15 @@ uvx --from git+https://github.com/github/spec-kit.git specify init <project_name
 uvx --from git+https://github.com/github/spec-kit.git specify init <project_name> --script ps
 ```
 
+### Use a Custom Template Source
+
+Need to bootstrap from a fork or an internal template build? Override the default upstream with either option:
+
+- `--template-repo owner/repo` (or `SPEC_KIT_TEMPLATE_REPO`) points the CLI at a different GitHub repository when downloading release assets.
+- `--template-path /path/to/template.zip` (or `SPEC_KIT_TEMPLATE_PATH`) skips the download entirely and uses a local ZIP archive or directory.
+
+Both overrides still run relocation and migration logic so the resulting project matches the `.specs/.specify` layout.
+
 ### Ignore Agent Tools Check
 
 If you prefer to get the templates without checking for the right tools:
@@ -64,7 +73,7 @@ After initialization, you should see the following commands available in your AI
 - `/plan` - Generate implementation plans  
 - `/tasks` - Break down into actionable tasks
 
-The `.specify/scripts` directory will contain both `.sh` and `.ps1` scripts.
+The `.specs/.specify/scripts` directory will contain both `.sh` and `.ps1` scripts.
 
 ## Troubleshooting
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -104,7 +104,7 @@ to be doing that are obvious from reading this. Because I don't know if there's 
 Finally, implement the solution:
 
 ```text
-implement specs/002-create-taskify/plan.md
+implement .specs/.specify/specs/002-create-taskify/plan.md
 ```
 
 ## Key Principles

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -15,3 +15,7 @@
   items:
     - name: Local Development
       href: local-development.md
+    - name: Agent Asset Packaging
+      href: agent-assets.md
+    - name: Custom Agent Assets
+      href: custom-agent-assets.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "specify-cli"
-version = "0.0.17"
+version = "0.0.19"
 description = "Specify CLI, part of GitHub Spec Kit. A tool to bootstrap your projects for Spec-Driven Development (SDD)."
 requires-python = ">=3.11"
 dependencies = [

--- a/scripts/bash/common.sh
+++ b/scripts/bash/common.sh
@@ -28,7 +28,10 @@ get_current_branch() {
     
     # For non-git repos, try to find the latest feature directory
     local repo_root=$(get_repo_root)
-    local specs_dir="$repo_root/specs"
+    local specs_dir="$repo_root/.specs/.specify/specs"
+    if [[ ! -d "$specs_dir" ]] && [[ -d "$repo_root/specs" ]]; then
+        specs_dir="$repo_root/specs"
+    fi
     
     if [[ -d "$specs_dir" ]]; then
         local latest_feature=""
@@ -81,7 +84,19 @@ check_feature_branch() {
     return 0
 }
 
-get_feature_dir() { echo "$1/specs/$2"; }
+get_feature_dir() {
+    local repo_root="$1"
+    local branch="$2"
+    local primary_path="$repo_root/.specs/.specify/specs/$branch"
+    local legacy_specs_path="$repo_root/.specs/specs/$branch"
+    if [[ -d "$primary_path" ]] || { [[ ! -d "$legacy_specs_path" ]] && [[ ! -d "$repo_root/specs/$branch" ]]; }; then
+        echo "$primary_path"
+    elif [[ -d "$legacy_specs_path" ]]; then
+        echo "$legacy_specs_path"
+    else
+        echo "$repo_root/specs/$branch"
+    fi
+}
 
 get_feature_paths() {
     local repo_root=$(get_repo_root)
@@ -92,6 +107,8 @@ get_feature_paths() {
         has_git_repo="true"
     fi
     
+    local specs_root="$repo_root/.specs"
+    mkdir -p "$specs_root/.specify"
     local feature_dir=$(get_feature_dir "$repo_root" "$current_branch")
     
     cat <<EOF

--- a/scripts/bash/create-new-feature.sh
+++ b/scripts/bash/create-new-feature.sh
@@ -22,7 +22,7 @@ fi
 find_repo_root() {
     local dir="$1"
     while [ "$dir" != "/" ]; do
-        if [ -d "$dir/.git" ] || [ -d "$dir/.specify" ]; then
+    if [ -d "$dir/.git" ] || [ -d "$dir/.specs" ] || [ -d "$dir/.specify" ]; then
             echo "$dir"
             return 0
         fi
@@ -50,7 +50,9 @@ fi
 
 cd "$REPO_ROOT"
 
-SPECS_DIR="$REPO_ROOT/specs"
+SPECS_ROOT="$REPO_ROOT/.specs"
+SPECIFY_ROOT="$SPECS_ROOT/.specify"
+SPECS_DIR="$SPECIFY_ROOT/specs"
 mkdir -p "$SPECS_DIR"
 
 HIGHEST=0
@@ -80,7 +82,7 @@ fi
 FEATURE_DIR="$SPECS_DIR/$BRANCH_NAME"
 mkdir -p "$FEATURE_DIR"
 
-TEMPLATE="$REPO_ROOT/.specify/templates/spec-template.md"
+TEMPLATE="$SPECIFY_ROOT/templates/spec-template.md"
 SPEC_FILE="$FEATURE_DIR/spec.md"
 if [ -f "$TEMPLATE" ]; then cp "$TEMPLATE" "$SPEC_FILE"; else touch "$SPEC_FILE"; fi
 

--- a/scripts/bash/setup-plan.sh
+++ b/scripts/bash/setup-plan.sh
@@ -37,7 +37,7 @@ check_feature_branch "$CURRENT_BRANCH" "$HAS_GIT" || exit 1
 mkdir -p "$FEATURE_DIR"
 
 # Copy plan template if it exists
-TEMPLATE="$REPO_ROOT/.specify/templates/plan-template.md"
+TEMPLATE="$REPO_ROOT/.specs/.specify/templates/plan-template.md"
 if [[ -f "$TEMPLATE" ]]; then
     cp "$TEMPLATE" "$IMPL_PLAN"
     echo "Copied plan template to $IMPL_PLAN"

--- a/scripts/bash/update-agent-context.sh
+++ b/scripts/bash/update-agent-context.sh
@@ -71,7 +71,7 @@ AUGGIE_FILE="$REPO_ROOT/.augment/rules/specify-rules.md"
 ROO_FILE="$REPO_ROOT/.roo/rules/specify-rules.md"
 
 # Template file
-TEMPLATE_FILE="$REPO_ROOT/.specify/templates/agent-file-template.md"
+TEMPLATE_FILE="$REPO_ROOT/.specs/.specify/templates/agent-file-template.md"
 
 # Global variables for parsed plan data
 NEW_LANG=""

--- a/scripts/powershell/create-new-feature.ps1
+++ b/scripts/powershell/create-new-feature.ps1
@@ -20,7 +20,7 @@ $featureDesc = ($FeatureDescription -join ' ').Trim()
 function Find-RepositoryRoot {
     param(
         [string]$StartDir,
-        [string[]]$Markers = @('.git', '.specify')
+    [string[]]$Markers = @('.git', '.specs', '.specify')
     )
     $current = Resolve-Path $StartDir
     while ($true) {
@@ -57,7 +57,11 @@ try {
 
 Set-Location $repoRoot
 
-$specsDir = Join-Path $repoRoot 'specs'
+$specsRoot = Join-Path $repoRoot '.specs'
+New-Item -ItemType Directory -Path $specsRoot -Force | Out-Null
+$specifyRoot = Join-Path $specsRoot '.specify'
+New-Item -ItemType Directory -Path $specifyRoot -Force | Out-Null
+$specsDir = Join-Path $specifyRoot 'specs'
 New-Item -ItemType Directory -Path $specsDir -Force | Out-Null
 
 $highest = 0
@@ -89,7 +93,7 @@ if ($hasGit) {
 $featureDir = Join-Path $specsDir $branchName
 New-Item -ItemType Directory -Path $featureDir -Force | Out-Null
 
-$template = Join-Path $repoRoot '.specify/templates/spec-template.md'
+$template = Join-Path $specifyRoot 'templates/spec-template.md'
 $specFile = Join-Path $featureDir 'spec.md'
 if (Test-Path $template) { 
     Copy-Item $template $specFile -Force 

--- a/scripts/powershell/setup-plan.ps1
+++ b/scripts/powershell/setup-plan.ps1
@@ -32,7 +32,7 @@ if (-not (Test-FeatureBranch -Branch $paths.CURRENT_BRANCH -HasGit $paths.HAS_GI
 New-Item -ItemType Directory -Path $paths.FEATURE_DIR -Force | Out-Null
 
 # Copy plan template if it exists, otherwise note it or create empty file
-$template = Join-Path $paths.REPO_ROOT '.specify/templates/plan-template.md'
+$template = Join-Path $paths.REPO_ROOT '.specs/.specify/templates/plan-template.md'
 if (Test-Path $template) { 
     Copy-Item $template $paths.IMPL_PLAN -Force
     Write-Output "Copied plan template to $($paths.IMPL_PLAN)"

--- a/scripts/powershell/update-agent-context.ps1
+++ b/scripts/powershell/update-agent-context.ps1
@@ -55,7 +55,7 @@ $KILOCODE_FILE = Join-Path $REPO_ROOT '.kilocode/rules/specify-rules.md'
 $AUGGIE_FILE   = Join-Path $REPO_ROOT '.augment/rules/specify-rules.md'
 $ROO_FILE      = Join-Path $REPO_ROOT '.roo/rules/specify-rules.md'
 
-$TEMPLATE_FILE = Join-Path $REPO_ROOT '.specify/templates/agent-file-template.md'
+$TEMPLATE_FILE = Join-Path $REPO_ROOT '.specs/.specify/templates/agent-file-template.md'
 
 # Parsed plan data placeholders
 $script:NEW_LANG = ''
@@ -109,7 +109,7 @@ function Validate-Environment {
     }
     if (-not (Test-Path $TEMPLATE_FILE)) {
         Write-Err "Template file not found at $TEMPLATE_FILE"
-        Write-Info 'Run specify init to scaffold .specify/templates, or add agent-file-template.md there.'
+    Write-Info 'Run specify init to scaffold .specs/.specify/templates, or add agent-file-template.md there.'
         exit 1
     }
 }

--- a/spec-driven.md
+++ b/spec-driven.md
@@ -81,7 +81,7 @@ This command transforms a simple feature description (the user-prompt) into a co
 1. **Automatic Feature Numbering**: Scans existing specs to determine the next feature number (e.g., 001, 002, 003)
 2. **Branch Creation**: Generates a semantic branch name from your description and creates it automatically
 3. **Template-Based Generation**: Copies and customizes the feature specification template with your requirements
-4. **Directory Structure**: Creates the proper `specs/[branch-name]/` structure for all related documents
+4. **Directory Structure**: Creates the proper `.specs/.specify/specs/[branch-name]/` structure for all related documents
 
 ### The `/plan` Command
 
@@ -125,7 +125,7 @@ Total: ~12 hours of documentation work
 
 # This automatically:
 # - Creates branch "003-chat-system"
-# - Generates specs/003-chat-system/spec.md
+# - Generates .specs/.specify/specs/003-chat-system/spec.md
 # - Populates it with structured requirements
 
 # Step 2: Generate implementation plan (5 minutes)
@@ -135,12 +135,12 @@ Total: ~12 hours of documentation work
 /tasks
 
 # This automatically creates:
-# - specs/003-chat-system/plan.md
-# - specs/003-chat-system/research.md (WebSocket library comparisons)
-# - specs/003-chat-system/data-model.md (Message and User schemas)
-# - specs/003-chat-system/contracts/ (WebSocket events, REST endpoints)
-# - specs/003-chat-system/quickstart.md (Key validation scenarios)
-# - specs/003-chat-system/tasks.md (Task list derived from the plan)
+# - .specs/.specify/specs/003-chat-system/plan.md
+# - .specs/.specify/specs/003-chat-system/research.md (WebSocket library comparisons)
+# - .specs/.specify/specs/003-chat-system/data-model.md (Message and User schemas)
+# - .specs/.specify/specs/003-chat-system/contracts/ (WebSocket events, REST endpoints)
+# - .specs/.specify/specs/003-chat-system/quickstart.md (Key validation scenarios)
+# - .specs/.specify/specs/003-chat-system/tasks.md (Task list derived from the plan)
 ```
 
 In 15 minutes, you have:
@@ -268,7 +268,7 @@ The templates transform the LLM from a creative writer into a disciplined specif
 
 ## The Constitutional Foundation: Enforcing Architectural Discipline
 
-At the heart of SDD lies a constitution—a set of immutable principles that govern how specifications become code. The constitution (`memory/constitution.md`) acts as the architectural DNA of the system, ensuring that every generated implementation maintains consistency, simplicity, and quality.
+At the heart of SDD lies a constitution—a set of immutable principles that govern how specifications become code. The constitution (`.specs/.specify/memory/constitution.md`) acts as the architectural DNA of the system, ensuring that every generated implementation maintains consistency, simplicity, and quality.
 
 ### The Nine Articles of Development
 

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -643,10 +643,11 @@ def download_and_extract_template(
         console.print("Extracting template...")
 
     def _merge_into_project(payload_root: Path) -> None:
+        resolved_project_path = project_path.resolve()
         for item in payload_root.iterdir():
-            dest_path = project_path / item.name
+            dest_path = resolved_project_path / item.name
             try:
-                if dest_path.resolve() == item.resolve():
+                if dest_path == item.resolve():
                     continue
             except FileNotFoundError:
                 pass

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -42,6 +42,7 @@ from rich.text import Text
 from rich.live import Live
 from rich.align import Align
 from rich.table import Table
+from .paths import get_specs_root, get_specify_root, specify_scripts_dir, specify_templates_dir
 from rich.tree import Tree
 from typer.core import TyperGroup
 
@@ -431,9 +432,19 @@ def init_git_repo(project_path: Path, quiet: bool = False) -> bool:
         os.chdir(original_cwd)
 
 
-def download_template_from_github(ai_assistant: str, download_dir: Path, *, script_type: str = "sh", verbose: bool = True, show_progress: bool = True, client: httpx.Client = None, debug: bool = False, github_token: str = None) -> Tuple[Path, dict]:
-    repo_owner = "github"
-    repo_name = "spec-kit"
+def download_template_from_github(
+    ai_assistant: str,
+    download_dir: Path,
+    *,
+    script_type: str = "sh",
+    verbose: bool = True,
+    show_progress: bool = True,
+    client: httpx.Client = None,
+    debug: bool = False,
+    github_token: str = None,
+    repo_owner: str = "github",
+    repo_name: str = "spec-kit",
+) -> Tuple[Path, dict]:
     if client is None:
         client = httpx.Client(verify=ssl_context)
     
@@ -543,135 +554,156 @@ def download_template_from_github(ai_assistant: str, download_dir: Path, *, scri
     return zip_path, metadata
 
 
-def download_and_extract_template(project_path: Path, ai_assistant: str, script_type: str, is_current_dir: bool = False, *, verbose: bool = True, tracker: StepTracker | None = None, client: httpx.Client = None, debug: bool = False, github_token: str = None) -> Path:
-    """Download the latest release and extract it to create a new project.
-    Returns project_path. Uses tracker if provided (with keys: fetch, download, extract, cleanup)
-    """
+def download_and_extract_template(
+    project_path: Path,
+    ai_assistant: str,
+    script_type: str,
+    is_current_dir: bool = False,
+    *,
+    verbose: bool = True,
+    tracker: StepTracker | None = None,
+    client: httpx.Client = None,
+    debug: bool = False,
+    github_token: str = None,
+    template_repo: Tuple[str, str] | None = None,
+    template_path: Path | None = None,
+) -> Path:
+    """Provision project scaffolding from a release archive or local template."""
     current_dir = Path.cwd()
-    
-    # Step: fetch + download combined
-    if tracker:
-        tracker.start("fetch", "contacting GitHub API")
-    try:
-        zip_path, meta = download_template_from_github(
-            ai_assistant,
-            current_dir,
-            script_type=script_type,
-            verbose=verbose and tracker is None,
-            show_progress=(tracker is None),
-            client=client,
-            debug=debug,
-            github_token=github_token
-        )
-        if tracker:
-            tracker.complete("fetch", f"release {meta['release']} ({meta['size']:,} bytes)")
-            tracker.add("download", "Download template")
-            tracker.complete("download", meta['filename'])
-    except Exception as e:
-        if tracker:
-            tracker.error("fetch", str(e))
+    repo_owner, repo_name = template_repo or ("github", "spec-kit")
+
+    local_template_dir: Path | None = None
+    zip_path: Path | None = None
+    temp_dir_ctx: tempfile.TemporaryDirectory | None = None
+    meta: dict = {}
+    cleanup_zip = False
+    using_local_template = template_path is not None
+
+    if template_path is not None:
+        template_source = Path(template_path).expanduser().resolve()
+        if not template_source.exists():
+            message = f"Template path not found: {template_source}"
+            if tracker:
+                tracker.error("fetch", message)
+            else:
+                console.print(f"[red]{message}[/red]")
+            raise typer.Exit(1)
+
+        if template_source.is_dir():
+            local_template_dir = template_source
+            if tracker:
+                tracker.skip("fetch", "Local template directory")
+                tracker.skip("download", template_source.name)
+            elif verbose:
+                console.print(f"[cyan]Using local template directory:[/cyan] {template_source}")
         else:
-            if verbose:
-                console.print(f"[red]Error downloading template:[/red] {e}")
-        raise
-    
+            zip_path = template_source
+            meta = {
+                "filename": zip_path.name,
+                "size": zip_path.stat().st_size,
+                "release": "local",
+            }
+            if tracker:
+                tracker.skip("fetch", "Local template archive")
+                tracker.complete("download", zip_path.name)
+            elif verbose:
+                console.print(f"[cyan]Using local template archive:[/cyan] {zip_path}")
+    else:
+        if tracker:
+            tracker.start("fetch", "contacting GitHub API")
+        try:
+            zip_path, meta = download_template_from_github(
+                ai_assistant,
+                current_dir,
+                script_type=script_type,
+                verbose=verbose and tracker is None,
+                show_progress=(tracker is None),
+                client=client,
+                debug=debug,
+                github_token=github_token,
+                repo_owner=repo_owner,
+                repo_name=repo_name,
+            )
+            cleanup_zip = True
+            if tracker:
+                tracker.complete("fetch", f"release {meta['release']} ({meta['size']:,} bytes)")
+                tracker.complete("download", meta['filename'])
+        except Exception as e:
+            if tracker:
+                tracker.error("fetch", str(e))
+            else:
+                if verbose:
+                    console.print(f"[red]Error downloading template:[/red] {e}")
+            raise
+
     if tracker:
         tracker.add("extract", "Extract template")
         tracker.start("extract")
     elif verbose:
         console.print("Extracting template...")
-    
+
+    def _merge_into_project(payload_root: Path) -> None:
+        for item in payload_root.iterdir():
+            dest_path = project_path / item.name
+            try:
+                if dest_path.resolve() == item.resolve():
+                    continue
+            except FileNotFoundError:
+                pass
+
+            if item.is_dir():
+                shutil.copytree(item, dest_path, dirs_exist_ok=True)
+            else:
+                dest_path.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(item, dest_path)
+
     try:
-        # Create project directory only if not using current directory
         if not is_current_dir:
-            project_path.mkdir(parents=True)
-        
-        with zipfile.ZipFile(zip_path, 'r') as zip_ref:
-            # List all files in the ZIP for debugging
-            zip_contents = zip_ref.namelist()
+            project_path.mkdir(parents=True, exist_ok=True)
+
+        if tracker and local_template_dir is None:
+            tracker.add("zip-list", "Archive contents")
+
+        if local_template_dir is not None:
+            extracted_items = list(local_template_dir.iterdir())
             if tracker:
                 tracker.start("zip-list")
-                tracker.complete("zip-list", f"{len(zip_contents)} entries")
-            elif verbose:
-                console.print(f"[cyan]ZIP contains {len(zip_contents)} items[/cyan]")
-            
-            # For current directory, extract to a temp location first
-            if is_current_dir:
-                with tempfile.TemporaryDirectory() as temp_dir:
-                    temp_path = Path(temp_dir)
-                    zip_ref.extractall(temp_path)
-                    
-                    # Check what was extracted
-                    extracted_items = list(temp_path.iterdir())
-                    if tracker:
-                        tracker.start("extracted-summary")
-                        tracker.complete("extracted-summary", f"temp {len(extracted_items)} items")
-                    elif verbose:
-                        console.print(f"[cyan]Extracted {len(extracted_items)} items to temp location[/cyan]")
-                    
-                    # Handle GitHub-style ZIP with a single root directory
-                    source_dir = temp_path
-                    if len(extracted_items) == 1 and extracted_items[0].is_dir():
-                        source_dir = extracted_items[0]
-                        if tracker:
-                            tracker.add("flatten", "Flatten nested directory")
-                            tracker.complete("flatten")
-                        elif verbose:
-                            console.print(f"[cyan]Found nested directory structure[/cyan]")
-                    
-                    # Copy contents to current directory
-                    for item in source_dir.iterdir():
-                        dest_path = project_path / item.name
-                        if item.is_dir():
-                            if dest_path.exists():
-                                if verbose and not tracker:
-                                    console.print(f"[yellow]Merging directory:[/yellow] {item.name}")
-                                # Recursively copy directory contents
-                                for sub_item in item.rglob('*'):
-                                    if sub_item.is_file():
-                                        rel_path = sub_item.relative_to(item)
-                                        dest_file = dest_path / rel_path
-                                        dest_file.parent.mkdir(parents=True, exist_ok=True)
-                                        shutil.copy2(sub_item, dest_file)
-                            else:
-                                shutil.copytree(item, dest_path)
-                        else:
-                            if dest_path.exists() and verbose and not tracker:
-                                console.print(f"[yellow]Overwriting file:[/yellow] {item.name}")
-                            shutil.copy2(item, dest_path)
-                    if verbose and not tracker:
-                        console.print(f"[cyan]Template files merged into current directory[/cyan]")
-            else:
-                # Extract directly to project directory (original behavior)
-                zip_ref.extractall(project_path)
-                
-                # Check what was extracted
-                extracted_items = list(project_path.iterdir())
+                tracker.complete("zip-list", f"{len(extracted_items)} items")
+            payload_root = local_template_dir
+        else:
+            temp_dir_ctx = tempfile.TemporaryDirectory()
+            temp_dir = Path(temp_dir_ctx.name)
+            with zipfile.ZipFile(zip_path, "r") as zip_ref:
+                zip_contents = zip_ref.namelist()
                 if tracker:
-                    tracker.start("extracted-summary")
-                    tracker.complete("extracted-summary", f"{len(extracted_items)} top-level items")
+                    tracker.start("zip-list")
+                    tracker.complete("zip-list", f"{len(zip_contents)} entries")
                 elif verbose:
-                    console.print(f"[cyan]Extracted {len(extracted_items)} items to {project_path}:[/cyan]")
-                    for item in extracted_items:
-                        console.print(f"  - {item.name} ({'dir' if item.is_dir() else 'file'})")
-                
-                # Handle GitHub-style ZIP with a single root directory
-                if len(extracted_items) == 1 and extracted_items[0].is_dir():
-                    # Move contents up one level
-                    nested_dir = extracted_items[0]
-                    temp_move_dir = project_path.parent / f"{project_path.name}_temp"
-                    # Move the nested directory contents to temp location
-                    shutil.move(str(nested_dir), str(temp_move_dir))
-                    # Remove the now-empty project directory
-                    project_path.rmdir()
-                    # Rename temp directory to project directory
-                    shutil.move(str(temp_move_dir), str(project_path))
-                    if tracker:
-                        tracker.add("flatten", "Flatten nested directory")
-                        tracker.complete("flatten")
-                    elif verbose:
-                        console.print(f"[cyan]Flattened nested directory structure[/cyan]")
-                    
+                    console.print(f"[cyan]ZIP contains {len(zip_contents)} items[/cyan]")
+                zip_ref.extractall(temp_dir)
+            extracted_items = list(temp_dir.iterdir())
+            payload_root = temp_dir
+
+        flatten_applied = False
+        if len(extracted_items) == 1 and extracted_items[0].is_dir():
+            payload_root = extracted_items[0]
+            flatten_applied = True
+
+        if flatten_applied:
+            if tracker:
+                tracker.add("flatten", "Flatten nested directory")
+                tracker.complete("flatten")
+            elif verbose:
+                console.print("[cyan]Flattened nested directory structure[/cyan]")
+
+        _merge_into_project(payload_root)
+
+        if tracker:
+            tracker.start("extracted-summary")
+            tracker.complete("extracted-summary", f"{len(list(payload_root.iterdir()))} payload items")
+        elif verbose:
+            console.print(f"[cyan]Template files copied to {project_path}[/cyan]")
+
     except Exception as e:
         if tracker:
             tracker.error("extract", str(e))
@@ -680,7 +712,6 @@ def download_and_extract_template(project_path: Path, ai_assistant: str, script_
                 console.print(f"[red]Error extracting template:[/red] {e}")
                 if debug:
                     console.print(Panel(str(e), title="Extraction Error", border_style="red"))
-        # Clean up project directory if created and not current directory
         if not is_current_dir and project_path.exists():
             shutil.rmtree(project_path)
         raise typer.Exit(1)
@@ -688,24 +719,27 @@ def download_and_extract_template(project_path: Path, ai_assistant: str, script_
         if tracker:
             tracker.complete("extract")
     finally:
-        if tracker:
-            tracker.add("cleanup", "Remove temporary archive")
-        # Clean up downloaded ZIP file
-        if zip_path.exists():
+        if temp_dir_ctx is not None:
+            temp_dir_ctx.cleanup()
+
+        if cleanup_zip and zip_path and zip_path.exists():
             zip_path.unlink()
             if tracker:
-                tracker.complete("cleanup")
+                tracker.complete("cleanup", "Removed downloaded archive")
             elif verbose:
                 console.print(f"Cleaned up: {zip_path.name}")
-    
+        elif using_local_template:
+            if tracker:
+                tracker.skip("cleanup", "Local template retained")
+
     return project_path
 
 
 def ensure_executable_scripts(project_path: Path, tracker: StepTracker | None = None) -> None:
-    """Ensure POSIX .sh scripts under .specify/scripts (recursively) have execute bits (no-op on Windows)."""
+    """Ensure POSIX .sh scripts under .specs/.specify/scripts (recursively) have execute bits (no-op on Windows)."""
     if os.name == "nt":
         return  # Windows: skip silently
-    scripts_root = project_path / ".specify" / "scripts"
+    scripts_root = specify_scripts_dir(project_path)
     if not scripts_root.is_dir():
         return
     failures: list[str] = []
@@ -745,6 +779,92 @@ def ensure_executable_scripts(project_path: Path, tracker: StepTracker | None = 
             for f in failures:
                 console.print(f"  - {f}")
 
+
+def relocate_non_agent_directories(project_path: Path, tracker: StepTracker | None = None) -> None:
+    """Move legacy non-agent directories into the consolidated .specs/.specify/ root."""
+    specs_root = get_specs_root(project_path)
+    specify_root = get_specify_root(project_path)
+
+    # Migrate from legacy .specify directory if present
+    legacy_root = project_path / ".specify"
+    migrated = 0
+    if legacy_root.is_dir():
+        for item in legacy_root.iterdir():
+            dest = specify_root / item.name
+            if dest.exists():
+                if item.is_dir():
+                    dest.mkdir(parents=True, exist_ok=True)
+                    for child in item.iterdir():
+                        target = dest / child.name
+                        if target.exists():
+                            continue
+                        shutil.move(str(child), str(target))
+                else:
+                    continue
+            else:
+                shutil.move(str(item), str(dest))
+            migrated += 1
+        try:
+            legacy_root.rmdir()
+        except OSError:
+            pass
+
+    non_agent_dirs = [
+        "plan",
+        "spec",
+        "notes",
+        "scratch",
+        "memory",
+        "docs",
+        "logs",
+        "specs",
+    ]
+
+    moved = 0
+    for name in non_agent_dirs:
+        source = project_path / name
+        if not source.exists():
+            continue
+        destination = specify_root / name
+        if destination.exists():
+            continue
+        shutil.move(str(source), str(destination))
+        moved += 1
+
+    nested_moved = 0
+    for item in specs_root.iterdir():
+        if item.name == ".specify":
+            continue
+        dest = specify_root / item.name
+        try:
+            if dest.exists():
+                if item.is_dir() and dest.is_dir():
+                    for child in item.iterdir():
+                        target = dest / child.name
+                        if target.exists():
+                            continue
+                        shutil.move(str(child), str(target))
+                    item.rmdir()
+                else:
+                    continue
+            else:
+                shutil.move(str(item), str(dest))
+                nested_moved += 1
+        except Exception:
+            continue
+
+    if tracker:
+        detail_parts = []
+        if migrated:
+            detail_parts.append(f"legacy {migrated}")
+        if moved:
+            detail_parts.append(f"moved {moved}")
+        if nested_moved:
+            detail_parts.append(f"nested {nested_moved}")
+        if detail_parts:
+            tracker.complete("relocate", ", ".join(detail_parts))
+        else:
+            tracker.skip("relocate", "no changes needed")
 @app.command()
 def init(
     project_name: str = typer.Argument(None, help="Name for your new project directory (optional if using --here)"),
@@ -757,6 +877,16 @@ def init(
     skip_tls: bool = typer.Option(False, "--skip-tls", help="Skip SSL/TLS verification (not recommended)"),
     debug: bool = typer.Option(False, "--debug", help="Show verbose diagnostic output for network and extraction failures"),
     github_token: str = typer.Option(None, "--github-token", help="GitHub token to use for API requests (or set GH_TOKEN or GITHUB_TOKEN environment variable)"),
+    template_repo: Optional[str] = typer.Option(
+        None,
+        "--template-repo",
+        help="Override template repository in owner/repo form (defaults to github/spec-kit or SPEC_KIT_TEMPLATE_REPO)",
+    ),
+    template_path: Optional[Path] = typer.Option(
+        None,
+        "--template-path",
+        help="Use a local template ZIP or directory instead of downloading (or set SPEC_KIT_TEMPLATE_PATH)",
+    ),
 ):
     """
     Initialize a new Specify project from the latest template.
@@ -930,6 +1060,30 @@ def init(
     
     console.print(f"[cyan]Selected AI assistant:[/cyan] {selected_ai}")
     console.print(f"[cyan]Selected script type:[/cyan] {selected_script}")
+
+    # Determine template source overrides
+    env_template_repo = os.getenv("SPEC_KIT_TEMPLATE_REPO")
+    env_template_path = os.getenv("SPEC_KIT_TEMPLATE_PATH")
+
+    repo_spec = template_repo or env_template_repo or "github/spec-kit"
+    try:
+        repo_owner, repo_name = repo_spec.split("/", 1)
+    except ValueError:
+        console.print(f"[red]Error:[/red] Invalid template repo '{repo_spec}'. Expected 'owner/repo'.")
+        raise typer.Exit(1)
+
+    template_path_value: Optional[Path]
+    if template_path is not None:
+        template_path_value = template_path.expanduser().resolve()
+    elif env_template_path:
+        template_path_value = Path(env_template_path).expanduser().resolve()
+    else:
+        template_path_value = None
+
+    if template_path_value:
+        console.print(f"[cyan]Template source override:[/cyan] {template_path_value}")
+    elif repo_owner != "github" or repo_name != "spec-kit":
+        console.print(f"[cyan]Template repo override:[/cyan] {repo_owner}/{repo_name}")
     
     # Download and set up project
     # New tree-based progress (no emojis); include earlier substeps
@@ -949,6 +1103,7 @@ def init(
         ("extract", "Extract template"),
         ("zip-list", "Archive contents"),
         ("extracted-summary", "Extraction summary"),
+        ("relocate", "Consolidate non-agent assets"),
         ("chmod", "Ensure scripts executable"),
         ("cleanup", "Cleanup"),
         ("git", "Initialize git repository"),
@@ -965,7 +1120,23 @@ def init(
             local_ssl_context = ssl_context if verify else False
             local_client = httpx.Client(verify=local_ssl_context)
 
-            download_and_extract_template(project_path, selected_ai, selected_script, here, verbose=False, tracker=tracker, client=local_client, debug=debug, github_token=github_token)
+            download_and_extract_template(
+                project_path,
+                selected_ai,
+                selected_script,
+                here,
+                verbose=False,
+                tracker=tracker,
+                client=local_client,
+                debug=debug,
+                github_token=github_token,
+                template_repo=(repo_owner, repo_name),
+                template_path=template_path_value,
+            )
+
+            # Consolidate non-agent assets under .specs/.specify
+            tracker.start("relocate")
+            relocate_non_agent_directories(project_path, tracker=tracker)
 
             # Ensure scripts are executable (POSIX)
             ensure_executable_scripts(project_path, tracker=tracker)

--- a/src/specify_cli/paths.py
+++ b/src/specify_cli/paths.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+def _run_git_toplevel() -> str | None:
+    try:
+        return (
+            subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True)
+            .strip()
+            or None
+        )
+    except Exception:
+        return None
+
+
+def get_repo_root() -> Path:
+    root = _run_git_toplevel()
+    if root:
+        return Path(root)
+    return Path.cwd()
+
+
+def get_specs_root(override: str | Path | None = None) -> Path:
+    if isinstance(override, Path):
+        root = (override / ".specs").expanduser().resolve()
+    else:
+        base = override or os.getenv("SPEC_KIT_DIR")
+        if base:
+            root = Path(base).expanduser().resolve()
+        else:
+            root = get_repo_root() / ".specs"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def ensure_dir(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def specs_subdir(name: str, base: Path | None = None) -> Path:
+    safe = name.strip().strip("/\\")
+    if not safe:
+        raise ValueError("Subdirectory name must not be empty")
+    return ensure_dir(get_specs_root(base) / safe)
+
+
+def get_specify_root(base: Path | None = None) -> Path:
+    return ensure_dir(get_specs_root(base) / ".specify")
+
+
+def specify_subdir(name: str, base: Path | None = None) -> Path:
+    safe = name.strip().strip("/\\")
+    if not safe:
+        raise ValueError("Subdirectory name must not be empty")
+    return ensure_dir(get_specify_root(base) / safe)
+
+
+def specify_scripts_dir(base: Path | None = None) -> Path:
+    return specify_subdir("scripts", base)
+
+
+def specify_templates_dir(base: Path | None = None) -> Path:
+    return specify_subdir("templates", base)
+
+
+def plan_dir(base: Path | None = None) -> Path:
+    return specify_subdir("plan", base)
+
+
+def spec_dir(base: Path | None = None) -> Path:
+    return specify_subdir("spec", base)
+
+
+def notes_dir(base: Path | None = None) -> Path:
+    return specify_subdir("notes", base)
+
+
+def memory_dir(base: Path | None = None) -> Path:
+    return specify_subdir("memory", base)
+
+
+def scratch_dir(base: Path | None = None) -> Path:
+    return specify_subdir("scratch", base)
+
+
+def docs_dir(base: Path | None = None) -> Path:
+    return specify_subdir("docs", base)
+
+
+def logs_dir(base: Path | None = None) -> Path:
+    return specify_subdir("logs", base)
+
+
+def features_dir(base: Path | None = None) -> Path:
+    return specify_subdir("specs", base)
+
+
+def contracts_dir(feature_path: Path) -> Path:
+    return ensure_dir(feature_path / "contracts")

--- a/src/specify_cli/paths.py
+++ b/src/specify_cli/paths.py
@@ -24,7 +24,11 @@ def get_repo_root() -> Path:
 
 def get_specs_root(override: str | Path | None = None) -> Path:
     if isinstance(override, Path):
-        root = (override / ".specs").expanduser().resolve()
+        # Treat path overrides as a base directory unless they already point at a
+        # '.specs' folder so callers can pass either the project root or the
+        # target specs directory explicitly.
+        expanded = override.expanduser().resolve()
+        root = expanded if expanded.name == ".specs" else (expanded / ".specs").resolve()
     else:
         base = override or os.getenv("SPEC_KIT_DIR")
         if base:

--- a/templates/commands/analyze.md
+++ b/templates/commands/analyze.md
@@ -15,7 +15,7 @@ Goal: Identify inconsistencies, duplications, ambiguities, and underspecified it
 
 STRICTLY READ-ONLY: Do **not** modify any files. Output a structured analysis report. Offer an optional remediation plan (user must explicitly approve before any follow-up editing commands would be invoked manually).
 
-Constitution Authority: The project constitution (`/memory/constitution.md`) is **non-negotiable** within this analysis scope. Constitution conflicts are automatically CRITICAL and require adjustment of the spec, plan, or tasks—not dilution, reinterpretation, or silent ignoring of the principle. If a principle itself needs to change, that must occur in a separate, explicit constitution update outside `/analyze`.
+Constitution Authority: The project constitution (`/.specs/.specify/memory/constitution.md`) is **non-negotiable** within this analysis scope. Constitution conflicts are automatically CRITICAL and require adjustment of the spec, plan, or tasks—not dilution, reinterpretation, or silent ignoring of the principle. If a principle itself needs to change, that must occur in a separate, explicit constitution update outside `/analyze`.
 
 Execution steps:
 
@@ -29,7 +29,7 @@ Execution steps:
    - Parse spec.md sections: Overview/Context, Functional Requirements, Non-Functional Requirements, User Stories, Edge Cases (if present).
    - Parse plan.md: Architecture/stack choices, Data Model references, Phases, Technical constraints.
    - Parse tasks.md: Task IDs, descriptions, phase grouping, parallel markers [P], referenced file paths.
-   - Load constitution `/memory/constitution.md` for principle validation.
+   - Load constitution `/.specs/.specify/memory/constitution.md` for principle validation.
 
 3. Build internal semantic models:
    - Requirements inventory: Each functional + non-functional requirement with a stable key (derive slug based on imperative phrase; e.g., "User can upload file" -> `user-can-upload-file`).

--- a/templates/commands/constitution.md
+++ b/templates/commands/constitution.md
@@ -8,11 +8,11 @@ User input:
 
 $ARGUMENTS
 
-You are updating the project constitution at `/memory/constitution.md`. This file is a TEMPLATE containing placeholder tokens in square brackets (e.g. `[PROJECT_NAME]`, `[PRINCIPLE_1_NAME]`). Your job is to (a) collect/derive concrete values, (b) fill the template precisely, and (c) propagate any amendments across dependent artifacts.
+You are updating the project constitution at `/.specs/.specify/memory/constitution.md`. This file is a TEMPLATE containing placeholder tokens in square brackets (e.g. `[PROJECT_NAME]`, `[PRINCIPLE_1_NAME]`). Your job is to (a) collect/derive concrete values, (b) fill the template precisely, and (c) propagate any amendments across dependent artifacts.
 
 Follow this execution flow:
 
-1. Load the existing constitution template at `/memory/constitution.md`.
+1. Load the existing constitution template at `/.specs/.specify/memory/constitution.md`.
    - Identify every placeholder token of the form `[ALL_CAPS_IDENTIFIER]`.
    **IMPORTANT**: The user might require less or more principles than the ones used in the template. If a number is specified, respect that - follow the general template. You will update the doc accordingly.
 
@@ -53,7 +53,7 @@ Follow this execution flow:
    - Dates ISO format YYYY-MM-DD.
    - Principles are declarative, testable, and free of vague language ("should" → replace with MUST/SHOULD rationale where appropriate).
 
-7. Write the completed constitution back to `/memory/constitution.md` (overwrite).
+7. Write the completed constitution back to `/.specs/.specify/memory/constitution.md` (overwrite).
 
 8. Output a final summary to the user with:
    - New version and bump rationale.
@@ -70,4 +70,4 @@ If the user supplies partial updates (e.g., only one principle revision), still 
 
 If critical info missing (e.g., ratification date truly unknown), insert `TODO(<FIELD_NAME>): explanation` and include in the Sync Impact Report under deferred items.
 
-Do not create a new template; always operate on the existing `/memory/constitution.md` file.
+Do not create a new template; always operate on the existing `/.specs/.specify/memory/constitution.md` file.

--- a/templates/commands/plan.md
+++ b/templates/commands/plan.md
@@ -21,10 +21,10 @@ Given the implementation details provided as an argument, do this:
    - Success criteria and acceptance criteria
    - Any technical constraints or dependencies mentioned
 
-3. Read the constitution at `/memory/constitution.md` to understand constitutional requirements.
+3. Read the constitution at `/.specs/.specify/memory/constitution.md` to understand constitutional requirements.
 
 4. Execute the implementation plan template:
-   - Load `/templates/plan-template.md` (already copied to IMPL_PLAN path)
+   - Load `/.specs/.specify/templates/plan-template.md` (already copied to IMPL_PLAN path)
    - Set Input path to FEATURE_SPEC
    - Run the Execution Flow (main) function steps 1-9
    - The template is self-contained and executable

--- a/templates/plan-template.md
+++ b/templates/plan-template.md
@@ -1,14 +1,14 @@
 ---
 description: "Implementation plan template for feature development"
 scripts:
-  sh: scripts/bash/update-agent-context.sh __AGENT__
-  ps: scripts/powershell/update-agent-context.ps1 -AgentType __AGENT__
+   sh: .specs/.specify/scripts/bash/update-agent-context.sh __AGENT__
+   ps: .specs/.specify/scripts/powershell/update-agent-context.ps1 -AgentType __AGENT__
 ---
 
 # Implementation Plan: [FEATURE]
 
 **Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]
-**Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
+**Input**: Feature specification from `/.specs/.specify/specs/[###-feature-name]/spec.md`
 
 ## Execution Flow (/plan command scope)
 ```
@@ -59,7 +59,7 @@ scripts:
 
 ### Documentation (this feature)
 ```
-specs/[###-feature]/
+.specs/.specify/specs/[###-feature]/
 ├── plan.md              # This file (/plan command output)
 ├── research.md          # Phase 0 output (/plan command)
 ├── data-model.md        # Phase 1 output (/plan command)
@@ -165,7 +165,7 @@ ios/ or android/
 *This section describes what the /tasks command will do - DO NOT execute during /plan*
 
 **Task Generation Strategy**:
-- Load `.specify/templates/tasks-template.md` as base
+- Load `.specs/.specify/templates/tasks-template.md` as base
 - Generate tasks from Phase 1 design docs (contracts, data model, quickstart)
 - Each contract → contract test task [P]
 - Each entity → model creation task [P] 
@@ -215,4 +215,4 @@ ios/ or android/
 - [ ] Complexity deviations documented
 
 ---
-*Based on Constitution v2.1.1 - See `/memory/constitution.md`*
+*Based on Constitution v2.1.1 - See `/.specs/.specify/memory/constitution.md`*

--- a/templates/tasks-template.md
+++ b/templates/tasks-template.md
@@ -1,6 +1,6 @@
 # Tasks: [FEATURE NAME]
 
-**Input**: Design documents from `/specs/[###-feature-name]/`
+**Input**: Design documents from `/.specs/.specify/specs/[###-feature-name]/`
 **Prerequisites**: plan.md (required), research.md, data-model.md, contracts/
 
 ## Execution Flow (main)


### PR DESCRIPTION
## Summary
- Centralize .specs/.specify path handling in the CLI via the new paths.py, updating relocation logic and template overrides to use it.
- Extend packaging and agent context scripts (bash + PowerShell) to rewrite assets into the new hierarchy and keep prompts aligned.
- Add comprehensive agent asset docs (agent-assets.md, custom-agent-assets.md) and refresh README/installation/quickstart content to explain overrides, packaging, and custom assets.
- Update templates, contribution guide, and changelog to reflect the new workflow and version bump.

## Testing
- uv run python -m compileall src
