### PR TITLE
feat: declarative layout, template resolver, packaging updates, and cross-shell parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,26 @@
 
 All notable changes to the Specify CLI will be documented in this file.
 
-The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
-and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [LATEST_VERSION] - RELEASE_DATE
+## [0.0.20] - 2025-09-27
 
 ### Added
 
-- Support for using `.` as a shorthand for current directory in `specify init .` command, equivalent to `--here` flag but more intuitive for users
+- Declarative layout support via `.specs/.specify/layout.yaml` defining `spec_roots`, `folder_strategy` (`flat`/`epic`/`product`), and canonical file names (e.g., `design.md`, `fprd.md`, `tasks.md`, `pprd.md`).
+- Runtime template resolver with assets override precedence (`.specs/.specify/templates/assets/*-template.md` before defaults).
+- New helper scripts (Bash/PowerShell): `read-layout`, `resolve-template`, `spec-root`.
 
-### Notes
+### Changed
 
-- This release note reflects upstream improvements; your local fork also includes `.specs/.specify` consolidation and template source override features below.
+- Plan output renamed to `design.md`; FPRD is `fprd.md`; optional legacy stub `spec.md` retained via compatibility setting.
+- Packaging script relocates and rewrites prompts to the consolidated `.specs/.specify` structure and promotes `templates/layout.yaml` into packages.
+- Cross-shell parity for all core helpers (`check-prerequisites`, `create-new-feature`, `setup-plan`) with JSON outputs for agent orchestration.
+
+### Docs
+
+- Updated README and docs/agent-assets.md to describe the new layout, overrides, and packaging workflow.
 
 ## [0.0.19] - 2025-09-24
 
@@ -34,84 +42,109 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - Consolidated all non-agent project assets under a new `/.specs/.specify` hierarchy while keeping agent folders at the repository root for IDE autodiscovery.
 - Updated the Specify CLI, packaging scripts, shell/PowerShell helpers, and command templates to reference the relocated directories.
+- Added migration logic and legacy fallbacks so existing projects using `.specify/` or top-level `specs/` continue to function.
 
 ## [0.0.17] - 2025-09-22
 
 ### Added
 
 - New `/clarify` command template to surface up to 5 targeted clarification questions for an existing spec and persist answers into a Clarifications section in the spec.
+- New `/analyze` command template providing a non-destructive cross-artifact discrepancy and alignment report (spec, clarifications, plan, tasks, constitution) inserted after `/tasks` and before `/implement`.
+	- Note: Constitution rules are explicitly treated as non-negotiable; any conflict is a CRITICAL finding requiring artifact remediation, not weakening of principles.
 
 ## [0.0.16] - 2025-09-22
 
 ### Added
 
 - `--force` flag for `init` command to bypass confirmation when using `--here` in a non-empty directory and proceed with merging/overwriting files.
+
 ## [0.0.15] - 2025-09-21
 
 ### Added
 
 - Support for Roo Code.
+
 ## [0.0.14] - 2025-09-21
 
 ### Changed
 
 - Error messages are now shown consistently.
+
 ## [0.0.13] - 2025-09-21
 
 ### Added
 
 - Support for Kilo Code. Thank you [@shahrukhkhan489](https://github.com/shahrukhkhan489) with [#394](https://github.com/github/spec-kit/pull/394).
+- Support for Auggie CLI. Thank you [@hungthai1401](https://github.com/hungthai1401) with [#137](https://github.com/github/spec-kit/pull/137).
+- Agent folder security notice displayed after project provisioning completion, warning users that some agents may store credentials or auth tokens in their agent folders and recommending adding relevant folders to `.gitignore` to prevent accidental credential leakage.
+
 ### Changed
 
 - Warning displayed to ensure that folks are aware that they might need to add their agent folder to `.gitignore`.
+- Cleaned up the `check` command output.
+
 ## [0.0.12] - 2025-09-21
 
 ### Changed
 
 - Added additional context for OpenAI Codex users - they need to set an additional environment variable, as described in [#417](https://github.com/github/spec-kit/issues/417).
+
 ## [0.0.11] - 2025-09-20
 
 ### Added
 
 - Codex CLI support (thank you [@honjo-hiroaki-gtt](https://github.com/honjo-hiroaki-gtt) for the contribution in [#14](https://github.com/github/spec-kit/pull/14))
+- Codex-aware context update tooling (Bash and PowerShell) so feature plans refresh `AGENTS.md` alongside existing assistants without manual edits.
+
 ## [0.0.10] - 2025-09-20
 
 ### Fixed
 
 - Addressed [#378](https://github.com/github/spec-kit/issues/378) where a GitHub token may be attached to the request when it was empty.
+
 ## [0.0.9] - 2025-09-19
 
 ### Changed
 
 - Improved agent selector UI with cyan highlighting for agent keys and gray parentheses for full names
+
 ## [0.0.8] - 2025-09-19
 
 ### Added
 
 - Windsurf IDE support as additional AI assistant option (thank you [@raedkit](https://github.com/raedkit) for the work in [#151](https://github.com/github/spec-kit/pull/151))
+- GitHub token support for API requests to handle corporate environments and rate limiting (contributed by [@zryfish](https://github.com/@zryfish) in [#243](https://github.com/github/spec-kit/pull/243))
+
 ### Changed
 
 - Updated README with Windsurf examples and GitHub token usage
+- Enhanced release workflow to include Windsurf templates
+
 ## [0.0.7] - 2025-09-18
 
 ### Changed
 
 - Updated command instructions in the CLI.
+- Cleaned up the code to not render agent-specific information when it's generic.
+
 
 ## [0.0.6] - 2025-09-17
 
 ### Added
 
+- opencode support as additional AI assistant option
 
 ## [0.0.5] - 2025-09-17
 
 ### Added
 
+- Qwen Code support as additional AI assistant option
 
 ## [0.0.4] - 2025-09-14
 
 ### Added
 
+- SOCKS proxy support for corporate environments via `httpx[socks]` dependency
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "specify-cli"
-version = "0.0.19"
+version = "0.0.20"
 description = "Specify CLI, part of GitHub Spec Kit. A tool to bootstrap your projects for Spec-Driven Development (SDD)."
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
Summary

This PR introduces a declarative layout and robust template resolution pipeline, updates packaging to normalize paths and promote layout configuration, and provides cross-shell parity for core helper scripts. It also updates docs and bumps Specify CLI to 0.0.20 per policy.

Key changes

Declarative layout (.specs/.specify/layout.yaml)
- Defines spec_roots, folder_strategy (flat/epic/product), and canonical file names (design.md, fprd.md, tasks.md, pprd.md, etc.)
- Scripts read this file at runtime; no hardcoded paths
- Optional legacy stub (spec.md) for compatibility

Template resolution with assets override
- New helpers resolve templates by key (spec/plan/tasks/pprd), preferring .specs/.specify/templates/assets/*-template.md overrides before defaults
- Works in both Bash and PowerShell; can emit JSON for agent orchestration

Cross-shell parity and non-git support
- Bash + PowerShell implementations for: read-layout, resolve-template, spec-root, create-new-feature, check-prerequisites, setup-plan
- SPECIFY_FEATURE env var allows working without git branches (useful for --no-git init)

Packaging workflow
- .github/workflows/scripts/create-release-packages.sh now:
  - Relocates memory/plan/spec/notes/scratch/docs/logs/specs under .specs/.specify/
  - Copies only the requested script variant into .specs/.specify/scripts
  - Promotes templates/layout.yaml to .specs/.specify/layout.yaml in the package
  - Generates agent-specific commands in the correct locations with normalized path references to .specs/.specify
  - Injects the proper script command into plan-template.md (and assets override) and strips frontmatter

Command templates and docs
- Added: templates/commands/pprd.md, templates/commands/pprd-clarify.md, templates/commands/fprds.md
- Updated: templates/commands/specify.md, templates/commands/plan.md, templates/commands/tasks.md
- Updated plan-template.md (writes design.md) and tasks-template.md; added pprd-template.md and assets/* templates
- README and docs/agent-assets.md updated to describe layout, overrides, and packaging

CLI updates
- src/specify_cli/__init__.py: extended agent list, improved checks, template source overrides, and init UX
- pyproject.toml: version bump to 0.0.20
- CHANGELOG.md: new 0.0.20 entry covering layout/resolver/packaging/script parity

Why
- Aligns authoring and runtime with a flexible, declarative layout
- Simplifies downstream customization via assets overrides
- Improves cross-platform support (Windows PowerShell parity)
- Normalizes packaged output for all agents to the consolidated .specs/.specify structure

How to validate
1) Build a package locally (optional):
   - AGENTS=claude SCRIPTS=sh bash .github/workflows/scripts/create-release-packages.sh v0.0.20
2) Scaffold a demo project with the local package:
   - uv run specify init tmp/demo --ai claude --script sh --template-path .genreleases/spec-kit-template-claude-sh-v0.0.20.zip --no-git
3) Confirm:
   - .specs/.specify/layout.yaml exists and lists canonical file names and strategy
   - .specs/.specify/scripts contains the selected script variant
   - Commands under .claude/.qwen/.github/.cursor (etc.) reference .specs/.specify paths
   - /specify seeds fprd.md; /plan writes design.md; /tasks uses tasks-template.md

Notes
- This PR focuses on layout/templating/packaging; functional behavior of the CLI otherwise unchanged
- Upstream merge handled previously on sync branch to avoid conflicts with docs

Please review with an eye on naming cohesion across layout.yaml, scripts, and template instructions. Happy to split minor docs into a follow-up if preferred.