### PR TITLE
docs: add repo-specific Copilot instructions for AI agents

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,53 @@
+# Copilot instructions for this repository
+
+These notes orient AI coding agents to be productive quickly in this codebase. Keep advice concrete and specific to this repo.
+
+## Big picture
+- Purpose: Spec Kit provides the Specify CLI and scaffolding for Spec‑Driven Development (SDD). This repo is the toolkit and CLI, not an app template itself.
+- Core deliverable: a CLI named `specify` that bootstraps SDD projects with agent workflows, templates, and scripts.
+- Key modules:
+  - `src/specify_cli/__init__.py`: Typer-based CLI entry point, most logic lives here (banner, tool checks, init flow, download/resolve templates, UX rendering with Rich).
+  - `src/specify_cli/paths.py`: Single source of truth for file/folder locations (e.g., `get_specs_root`, `get_specify_root`, `specify_templates_dir`). Avoid hardcoding paths—use these helpers.
+- Templates live in `templates/` and docs in `docs/` (DocFX sources). Agent integration rules in `AGENTS.md`; product overview and CLI reference in `README.md`.
+
+## How things fit together
+- CLI flow (high level):
+  1) Parse args with Typer → 2) Optional tool checks (Claude, Cursor, etc.) → 3) Resolve template source (release ZIP, local dir via `--template-path`, or `SPEC_KIT_TEMPLATE_PATH`) → 4) Extract to project → 5) Write agent-specific command files and helper scripts.
+- Declarative layout (in scaffolded projects): `.specs/.specify/layout.yaml` defines `spec_roots`, `folder_strategy` (flat/epic/product), and canonical filenames (`design.md`, `fprd.md`, `pprd.md`, `tasks.md`). Scripts read this at runtime—do not assume filenames or fixed directories.
+- Template resolution prefers overrides at `.specs/.specify/templates/assets/*-template.md` before built-ins under `.specs/.specify/templates/`.
+
+## Developer workflows (this repo)
+- Run without install:
+  - `python -m src.specify_cli --help`
+  - `python -m src.specify_cli init demo --ai claude --ignore-agent-tools --script sh`
+- Using uv:
+  - Editable install: `uv venv && source .venv/bin/activate && uv pip install -e . && specify --help`
+  - Local run w/o install: `uvx --from . specify init demo --ai copilot --ignore-agent-tools --script ps`
+  - Build a wheel: `uv build`
+- Docs (DocFX): `cd docs && docfx docfx.json --serve` then open http://localhost:8080.
+- Policy: If you change `src/specify_cli/__init__.py`, bump `version` in `pyproject.toml` and add a `CHANGELOG.md` entry (see `AGENTS.md`).
+
+## Project conventions
+- Entry point: `[project.scripts] specify = "specify_cli:main"` in `pyproject.toml`. Keep help text and README examples in sync with CLI behavior.
+- Supported agents: enumerated in `AI_CHOICES` (`__init__.py`). Adding agents requires code + docs + release script updates; follow `AGENTS.md` (directory names, file formats, argument placeholders differ by agent).
+- IDE vs CLI agents:
+  - IDE: Copilot (`.github/prompts/`), Windsurf (`.windsurf/workflows/`).
+  - CLI: Claude (`.claude/commands/`), Cursor (`.cursor/commands/`), Gemini/Qwen (TOML in `.gemini/.qwen`), opencode, etc. Placeholders: `$ARGUMENTS` (md) vs `{{args}}` (toml).
+- Environment variables:
+  - `SPEC_KIT_TEMPLATE_REPO` / `SPEC_KIT_TEMPLATE_PATH` to override template source.
+  - `SPECIFY_FEATURE`, `SPECIFY_PRODUCT`, `SPECIFY_EPIC` guide feature routing when using product/epic strategies.
+  - `GH_TOKEN`/`GITHUB_TOKEN` improve GitHub API rate limits.
+- Filenames used in scaffolded projects: plan → `design.md` (not `plan.md`); feature PRD → `fprd.md`; a legacy `spec.md` stub may be written for compatibility.
+
+## What to reuse
+- Paths: use `get_specs_root`, `get_specify_root`, `specify_templates_dir` from `src/specify_cli/paths.py` (don’t hardcode `.specs` paths).
+- Tool checks and progress: reuse `check_tool`, `check_tool_for_tracker`, and `StepTracker` from `__init__.py` for consistent UX.
+- Scripts: keep bash and PowerShell parity under `scripts/bash/` and `scripts/powershell/`; wire into templates as needed.
+
+## Quick examples
+- Local run via uvx: `uvx --from . specify init myproj --ai cursor --ignore-agent-tools --script sh`
+- Direct module call: `python -m src.specify_cli check`
+
+Key refs: `README.md`, `AGENTS.md`, `docs/local-development.md`, `src/specify_cli/__init__.py`, `src/specify_cli/paths.py`.
+
+If anything here seems out of date with the code, note it and I’ll update this file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ All notable changes to the Specify CLI will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.20] - 2025-09-27
+
+### Added
+
+- Declarative layout support via `.specs/.specify/layout.yaml` defining `spec_roots`, `folder_strategy` (`flat`/`epic`/`product`), and canonical file names (e.g., `design.md`, `fprd.md`, `tasks.md`, `pprd.md`).
+- Runtime template resolver with assets override precedence (`.specs/.specify/templates/assets/*-template.md` before defaults).
+- New helper scripts (Bash/PowerShell): `read-layout`, `resolve-template`, `spec-root`.
+
+### Changed
+
+- Plan output renamed to `design.md`; FPRD is `fprd.md`; optional legacy stub `spec.md` retained via compatibility setting.
+- Packaging script relocates and rewrites prompts to the consolidated `.specs/.specify` structure and promotes `templates/layout.yaml` into packages.
+- Cross-shell parity for all core helpers (`check-prerequisites`, `create-new-feature`, `setup-plan`) with JSON outputs for agent orchestration.
+
+### Docs
+
+- Updated README and docs/agent-assets.md to describe the new layout, overrides, and packaging workflow.
+
 ## [0.0.19] - 2025-09-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -212,10 +212,13 @@ After running `specify init`, your AI coding agent will have access to these sla
 | `/constitution` | Create or update project governing principles and development guidelines |
 | `/specify`      | Define what you want to build (requirements and user stories)        |
 | `/clarify`      | Clarify underspecified areas (must be run before `/plan` unless explicitly skipped; formerly `/quizme`) |
-| `/plan`         | Create technical implementation plans with your chosen tech stack     |
+| `/plan`         | Create technical implementation plans (writes `design.md`)            |
 | `/tasks`        | Generate actionable task lists for implementation                     |
 | `/analyze`      | Cross-artifact consistency & coverage analysis (run after /tasks, before /implement) |
 | `/implement`    | Execute all tasks to build the feature according to the plan         |
+| `/pprd`         | Create a Portfolio/Product PRD at the canonical specs root (writes `pprd.md`) |
+| `/pprd-clarify` | Clarify underspecified areas in a PPRD and update it in-place         |
+| `/fprds`        | Decompose a PPRD into Feature PRDs (creates feature folders + `fprd.md`) |
 
 ### Environment Variables
 
@@ -224,6 +227,23 @@ After running `specify init`, your AI coding agent will have access to these sla
 | `SPECIFY_FEATURE`        | Override feature detection for non-Git repositories. Set to the feature directory name (e.g., `001-photo-albums`) to work on a specific feature when not using Git branches.<br/>**Must be set in the context of the agent you're working with prior to using `/plan` or follow-up commands. |
 | `SPEC_KIT_TEMPLATE_REPO` | Alternative template repository in `owner/repo` form. Takes the same value as `--template-repo`. |
 | `SPEC_KIT_TEMPLATE_PATH` | Absolute or relative path to a local template ZIP or directory. Takes the same value as `--template-path`. |
+| `SPECIFY_PRODUCT`        | Hint for feature folder routing when using product-level hierarchy (used by `/fprds` and feature creation scripts). |
+| `SPECIFY_EPIC`           | Hint for epic folder routing when using epic-level hierarchy (used by `/fprds` and feature creation scripts). |
+
+### Declarative Layout & Template Overrides
+
+- Projects include a layout file at `.specs/.specify/layout.yaml` that defines:
+  - `spec_roots` (e.g., `specs`), `folder_strategy` (`flat`, `epic`, or `product`)
+  - Canonical file names: `pprd.md`, `fprd.md`, `design.md`, `tasks.md`, `traceability_index.md`, etc.
+- Helper scripts consult the layout at runtime:
+  - `.specs/.specify/scripts/bash/read-layout.sh` and `spec-root.sh` (PowerShell equivalents included)
+  - Feature creation and plan setup honor file names and folder strategy
+- Template resolution supports assets overrides:
+  - Drop custom layouts in `.specs/.specify/templates/assets/*-template.md`
+  - Resolver prefers assets first, then defaults in `.specs/.specify/templates/`
+- Notable file naming updates:
+  - Plan output is `design.md` (formerly `plan.md`)
+  - Feature PRD file is `fprd.md` (optionally a legacy `spec.md` stub can be written for compatibility)
 
 ## 📚 Core philosophy
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The `specify` command supports the following options:
 | `--skip-tls`           | Flag     | Skip SSL/TLS verification (not recommended)                                 |
 | `--debug`              | Flag     | Enable detailed debug output for troubleshooting                            |
 | `--github-token`       | Option   | GitHub token for API requests (or set GH_TOKEN/GITHUB_TOKEN env variable)  |
-| `--template-repo`      | Option   | Override the template release source (`owner/repo`). Defaults to `github/spec-kit` or `SPEC_KIT_TEMPLATE_REPO`. |
+| `--template-repo`      | Option   | Override the template release source (`owner/repo`). Defaults to `Jrakru/spec-kit` or `SPEC_KIT_TEMPLATE_REPO`. |
 | `--template-path`      | Option   | Use a local template ZIP or directory instead of downloading. Mirrors `SPEC_KIT_TEMPLATE_PATH`. |
 
 ### Examples

--- a/docs/agent-assets.md
+++ b/docs/agent-assets.md
@@ -48,7 +48,7 @@ The same script is invoked locally or by CI workflows. Because it produces a pla
 
 ## Using Packaged Templates
 
-The `specify` CLI downloads these archives by default from the `github/spec-kit` releases. You can direct the CLI to alternate sources using:
+The `specify` CLI downloads these archives by default from the `Jrakru/spec-kit` releases. You can direct the CLI to alternate sources using:
 
 - `--template-repo owner/repo` or `SPEC_KIT_TEMPLATE_REPO` to pull from a forked release.
 - `--template-path /path/to/template.zip` or `SPEC_KIT_TEMPLATE_PATH` to scaffold from a local archive or directory (handy when testing output from `.genreleases/`).

--- a/docs/agent-assets.md
+++ b/docs/agent-assets.md
@@ -7,9 +7,10 @@ This guide explains how Spec Kit assembles the command prompts and supporting fi
 Each agent receives a curated slice of the repository that includes:
 
 - **Command prompts** sourced from `templates/commands/*.md`, rewritten into the agent-specific format (`.md`, `.prompt.md`, or `.toml`).
-- **Shared templates** (`plan-template.md`, `tasks-template.md`, `spec-template.md`, `agent-file-template.md`) and supporting documentation copied into `.specs/.specify/templates/` and `.specs/.specify/docs/`.
+- **Shared templates** (`spec-template.md`, `plan-template.md` -> writes `design.md`, `tasks-template.md`, `pprd-template.md`, `agent-file-template.md`) and supporting documentation copied into `.specs/.specify/templates/` and `.specs/.specify/docs/`.
 - **Automation scripts** copied into `.specs/.specify/scripts/<shell>/`, matching the `--script` variant selected during packaging (Bash or PowerShell).
 - **Project memory and supporting assets** relocated under `.specs/.specify/` to keep non-agent files together.
+ - **Layout configuration** copied to `.specs/.specify/layout.yaml` describing canonical roots, folder strategy, and file names.
 
 The packaging workflow guarantees that every generated archive adheres to the consolidated `.specs/.specify` directory structure introduced in v0.0.18.
 
@@ -19,12 +20,19 @@ The packaging workflow guarantees that every generated archive adheres to the co
 |-------------------------------|-----------------------------------|---------------------------------------|
 | Command prompts               | `templates/commands/*.md`         | `.<agent>/commands/` (format dependent)|
 | Agent context template        | `templates/agent-file-template.md`| `.specs/.specify/templates/`          |
-| Specification + plan templates| `templates/spec-template.md`, `templates/plan-template.md`, `templates/tasks-template.md` | `.specs/.specify/templates/` |
+| Spec/plan/tasks/PPRD layouts  | `templates/*.md`                  | `.specs/.specify/templates/`          |
+| Template overrides (assets)   | `templates/assets/*-template.md`  | `.specs/.specify/templates/assets/`   |
+| Layout configuration          | `templates/layout.yaml`           | `.specs/.specify/layout.yaml`         |
 | Automation scripts            | `scripts/bash/`, `scripts/powershell/` | `.specs/.specify/scripts/bash/` or `.specs/.specify/scripts/powershell/` |
 | Constitution (memory)         | `memory/constitution.md`          | `.specs/.specify/memory/constitution.md` |
 | Docs                          | `docs/`                           | `.specs/.specify/docs/`               |
 
 The original prompt templates still reference placeholder paths such as `scripts/bash/...` or `/memory/constitution.md`. During packaging these references are rewritten to `.specs/.specify/...` so the generated projects align with the new hierarchy without modifying the authoring files in-place.
+
+In addition, generated projects resolve layout files dynamically at runtime using helper scripts:
+
+- `.specs/.specify/scripts/bash/resolve-template.sh` (and PowerShell variant) selects template bodies, preferring `templates/assets/*-template.md` overrides when present.
+- `.specs/.specify/scripts/bash/read-layout.sh` and `spec-root.sh` (and PowerShell variants) read `.specs/.specify/layout.yaml` to determine roots, folder strategy, and canonical file names (e.g., `design.md`, `fprd.md`, `pprd.md`).
 
 ## Packaging Workflow
 
@@ -60,7 +68,11 @@ uv run specify init tmp/claude-demo \
   --no-git
 ```
 
-Inspect `tmp/claude-demo/.specs/.specify/` and `tmp/claude-demo/.claude/commands/` to ensure prompts reference the new paths.
+Inspect `tmp/claude-demo/.specs/.specify/` and `tmp/claude-demo/.claude/commands/` to ensure prompts reference the new paths. Confirm that:
+
+- `layout.yaml` exists under `.specs/.specify/` and lists `spec_roots`, `folder_strategy`, and `files` keys.
+- `templates/assets/` contains overrides you expect (e.g., `PPRD-template.md`).
+- Scripts under `.specs/.specify/scripts/<shell>/` include `resolve-template.sh`, `read-layout.sh`, and `spec-root.sh`.
 
 ## Adding or Updating Agents
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "specify-cli"
-version = "0.0.19"
+version = "0.0.20"
 description = "Specify CLI, part of GitHub Spec Kit. A tool to bootstrap your projects for Spec-Driven Development (SDD)."
 requires-python = ">=3.11"
 dependencies = [

--- a/scripts/bash/check-prerequisites.sh
+++ b/scripts/bash/check-prerequisites.sh
@@ -107,7 +107,7 @@ if [[ ! -d "$FEATURE_DIR" ]]; then
 fi
 
 if [[ ! -f "$IMPL_PLAN" ]]; then
-    echo "ERROR: plan.md not found in $FEATURE_DIR" >&2
+    echo "ERROR: $(basename "$IMPL_PLAN") not found in $FEATURE_DIR" >&2
     echo "Run /plan first to create the implementation plan." >&2
     exit 1
 fi

--- a/scripts/bash/create-new-feature.sh
+++ b/scripts/bash/create-new-feature.sh
@@ -22,8 +22,13 @@ fi
 find_repo_root() {
     local dir="$1"
     while [ "$dir" != "/" ]; do
-    if [ -d "$dir/.git" ] || [ -d "$dir/.specs" ] || [ -d "$dir/.specify" ]; then
-            echo "$dir"
+        if [ -d "$dir/.git" ] || [ -d "$dir/.specs" ] || [ -d "$dir/.specify" ]; then
+            # If we stopped inside the .specs folder, return its parent
+            if [ "$(basename "$dir")" = ".specs" ]; then
+                dirname "$dir"
+            else
+                echo "$dir"
+            fi
             return 0
         fi
         dir="$(dirname "$dir")"
@@ -35,6 +40,7 @@ find_repo_root() {
 # to searching for repository markers so the workflow still functions in repositories that
 # were initialised with --no-git.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
 
 if git rev-parse --show-toplevel >/dev/null 2>&1; then
     REPO_ROOT=$(git rev-parse --show-toplevel)
@@ -52,12 +58,19 @@ cd "$REPO_ROOT"
 
 SPECS_ROOT="$REPO_ROOT/.specs"
 SPECIFY_ROOT="$SPECS_ROOT/.specify"
-SPECS_DIR="$SPECIFY_ROOT/specs"
-mkdir -p "$SPECS_DIR"
+# Load layout to determine feature location and filenames
+if [ -x "$SCRIPT_DIR/read-layout.sh" ]; then
+    eval $("$SCRIPT_DIR/read-layout.sh")
+fi
+# Determine parent folder for numbering using a dummy branch placeholder
+DUMMY_BRANCH="000-placeholder"
+DUMMY_PATH="$(get_feature_dir "$REPO_ROOT" "$DUMMY_BRANCH")"
+FEATURE_PARENT_DIR="$(dirname "$DUMMY_PATH")"
+mkdir -p "$FEATURE_PARENT_DIR"
 
 HIGHEST=0
-if [ -d "$SPECS_DIR" ]; then
-    for dir in "$SPECS_DIR"/*; do
+if [ -d "$FEATURE_PARENT_DIR" ]; then
+    for dir in "$FEATURE_PARENT_DIR"/*; do
         [ -d "$dir" ] || continue
         dirname=$(basename "$dir")
         number=$(echo "$dirname" | grep -o '^[0-9]\+' || echo "0")
@@ -79,12 +92,27 @@ else
     >&2 echo "[specify] Warning: Git repository not detected; skipped branch creation for $BRANCH_NAME"
 fi
 
-FEATURE_DIR="$SPECS_DIR/$BRANCH_NAME"
+# Now compute final feature directory
+FEATURE_DIR="$(get_feature_dir "$REPO_ROOT" "$BRANCH_NAME")"
 mkdir -p "$FEATURE_DIR"
 
-TEMPLATE="$SPECIFY_ROOT/templates/spec-template.md"
-SPEC_FILE="$FEATURE_DIR/spec.md"
-if [ -f "$TEMPLATE" ]; then cp "$TEMPLATE" "$SPEC_FILE"; else touch "$SPEC_FILE"; fi
+SPEC_FILE="$FEATURE_DIR/${LAYOUT_FILES_FPRD:-fprd.md}"
+# Resolve content template via resolver (assets override if present)
+RESOLVED_TEMPLATE="$SPECIFY_ROOT/templates/spec-template.md"
+if [ -x "$SCRIPT_DIR/resolve-template.sh" ]; then
+    if RES_JSON="$($SCRIPT_DIR/resolve-template.sh --json spec 2>/dev/null)"; then
+        RESOLVED_TEMPLATE="$(printf '%s' "$RES_JSON" | sed -n 's/.*"TEMPLATE_PATH":"\([^"]*\)".*/\1/p')"
+    fi
+fi
+if [ -f "$RESOLVED_TEMPLATE" ]; then cp "$RESOLVED_TEMPLATE" "$SPEC_FILE"; else touch "$SPEC_FILE"; fi
+
+# Optional legacy stub for spec.md if enabled
+if [ "${LAYOUT_COMPAT_WRITE_STUB_SPEC:-$LAYOUT_COMPAT_WRITE_STUB_SPEC}" = "true" ]; then
+    STUB_NAME="${LAYOUT_COMPAT_STUB_NAME:-spec.md}"
+    if [ "$STUB_NAME" != "$(basename "$SPEC_FILE")" ]; then
+        printf "# Legacy spec stub\n\nThis repository uses a declarative layout. The canonical feature PRD lives at: \n\n- %s\n" "$(basename "$SPEC_FILE")" > "$FEATURE_DIR/$STUB_NAME"
+    fi
+fi
 
 # Set the SPECIFY_FEATURE environment variable for the current session
 export SPECIFY_FEATURE="$BRANCH_NAME"

--- a/scripts/bash/read-layout.sh
+++ b/scripts/bash/read-layout.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Emit environment assignments for layout configuration.
+# Usage: read-layout.sh [--json]
+# Looks for .specs/.specify/layout.yaml at repo root; falls back to defaults.
+
+JSON_MODE=false
+for arg in "$@"; do
+  case "$arg" in
+    --json) JSON_MODE=true ;;
+    --help|-h) echo "Usage: $0 [--json]"; exit 0 ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+REPO_ROOT="$(get_repo_root)"
+CFG_PATH="$REPO_ROOT/.specs/.specify/layout.yaml"
+
+# Defaults
+LAYOUT_VERSION="1"
+LAYOUT_SPEC_ROOTS=("specs" ".specs/.specify/specs")
+LAYOUT_FOLDER_STRATEGY="epic"
+LAYOUT_FILES_FPRD="fprd.md"
+LAYOUT_FILES_PPRD="pprd.md"
+LAYOUT_FILES_REQUIREMENTS="requirements.md"
+LAYOUT_FILES_DESIGN="design.md"
+LAYOUT_FILES_TASKS="tasks.md"
+LAYOUT_FILES_RESEARCH="research.md"
+LAYOUT_FILES_QUICKSTART="quickstart.md"
+LAYOUT_FILES_TRACEABILITY_INDEX="traceability_index.md"
+LAYOUT_FILES_CONTRACTS_DIR="contracts"
+LAYOUT_FILES_PROGRESS_LOG="progress_log.md"
+LAYOUT_FILES_PARKING_LOT="parking_lot.md"
+LAYOUT_FILES_INDEX="index.yaml"
+LAYOUT_COMPAT_WRITE_STUB_SPEC="true"
+LAYOUT_COMPAT_STUB_NAME="spec.md"
+LAYOUT_CATALOG_PATH="specs/catalog.yaml"
+
+if [[ -f "$CFG_PATH" ]]; then
+  state="root"
+  section=""
+  while IFS= read -r raw || [[ -n "$raw" ]]; do
+    line="${raw%%#*}"
+    line="${line%$'\r'}"
+    [[ -z "${line//[[:space:]]/}" ]] && continue
+    # Top-level list: spec_roots
+    if [[ $line =~ ^spec_roots: ]]; then
+      section="spec_roots"; continue
+    fi
+    if [[ $line =~ ^files: ]]; then section="files"; continue; fi
+    if [[ $line =~ ^compat: ]]; then section="compat"; continue; fi
+    if [[ $line =~ ^catalog: ]]; then section="catalog"; continue; fi
+    if [[ $line =~ ^id_policy:|^defaults: ]]; then section="skip"; continue; fi
+
+    if [[ $line =~ ^version:[[:space:]]*([0-9]+) ]]; then LAYOUT_VERSION="${BASH_REMATCH[1]}"; continue; fi
+    if [[ $line =~ ^folder_strategy:[[:space:]]*"?([a-zA-Z0-9_-]+)"? ]]; then LAYOUT_FOLDER_STRATEGY="${BASH_REMATCH[1]}"; continue; fi
+
+    case "$section" in
+      spec_roots)
+        if [[ $line =~ ^[[:space:]]*-[[:space:]]*"?([^"']+)"? ]]; then
+          LAYOUT_SPEC_ROOTS+=("${BASH_REMATCH[1]}")
+        fi
+        ;;
+      files)
+        if [[ $line =~ fprd:[[:space:]]*"?([^"']+)"? ]]; then LAYOUT_FILES_FPRD="${BASH_REMATCH[1]}"; fi
+        if [[ $line =~ pprd:[[:space:]]*"?([^"']+)"? ]]; then LAYOUT_FILES_PPRD="${BASH_REMATCH[1]}"; fi
+        if [[ $line =~ requirements:[[:space:]]*"?([^"']+)"? ]]; then LAYOUT_FILES_REQUIREMENTS="${BASH_REMATCH[1]}"; fi
+        if [[ $line =~ design:[[:space:]]*"?([^"']+)"? ]]; then LAYOUT_FILES_DESIGN="${BASH_REMATCH[1]}"; fi
+        if [[ $line =~ tasks:[[:space:]]*"?([^"']+)"? ]]; then LAYOUT_FILES_TASKS="${BASH_REMATCH[1]}"; fi
+        if [[ $line =~ research:[[:space:]]*"?([^"']+)"? ]]; then LAYOUT_FILES_RESEARCH="${BASH_REMATCH[1]}"; fi
+        if [[ $line =~ quickstart:[[:space:]]*"?([^"']+)"? ]]; then LAYOUT_FILES_QUICKSTART="${BASH_REMATCH[1]}"; fi
+        if [[ $line =~ traceability_index:[[:space:]]*"?([^"']+)"? ]]; then LAYOUT_FILES_TRACEABILITY_INDEX="${BASH_REMATCH[1]}"; fi
+        if [[ $line =~ contracts_dir:[[:space:]]*"?([^"']+)"? ]]; then LAYOUT_FILES_CONTRACTS_DIR="${BASH_REMATCH[1]}"; fi
+        if [[ $line =~ progress_log:[[:space:]]*"?([^"']+)"? ]]; then LAYOUT_FILES_PROGRESS_LOG="${BASH_REMATCH[1]}"; fi
+        if [[ $line =~ parking_lot:[[:space:]]*"?([^"']+)"? ]]; then LAYOUT_FILES_PARKING_LOT="${BASH_REMATCH[1]}"; fi
+        if [[ $line =~ index:[[:space:]]*"?([^"']+)"? ]]; then LAYOUT_FILES_INDEX="${BASH_REMATCH[1]}"; fi
+        ;;
+      compat)
+        if [[ $line =~ write_redirect_stub_spec_md:[[:space:]]*(true|false) ]]; then LAYOUT_COMPAT_WRITE_STUB_SPEC="${BASH_REMATCH[1]}"; fi
+        if [[ $line =~ stub_name:[[:space:]]*"?([^"']+)"? ]]; then LAYOUT_COMPAT_STUB_NAME="${BASH_REMATCH[1]}"; fi
+        ;;
+      catalog)
+        if [[ $line =~ path:[[:space:]]*"?([^"']+)"? ]]; then LAYOUT_CATALOG_PATH="${BASH_REMATCH[1]}"; fi
+        ;;
+    esac
+  done < "$CFG_PATH"
+fi
+
+emit() {
+  echo "LAYOUT_VERSION='$LAYOUT_VERSION'"
+  echo -n "LAYOUT_SPEC_ROOTS='"; (IFS=,; echo -n "${LAYOUT_SPEC_ROOTS[*]}"); echo "'"
+  echo "LAYOUT_FOLDER_STRATEGY='$LAYOUT_FOLDER_STRATEGY'"
+  echo "LAYOUT_FILES_FPRD='$LAYOUT_FILES_FPRD'"
+  echo "LAYOUT_FILES_PPRD='$LAYOUT_FILES_PPRD'"
+  echo "LAYOUT_FILES_REQUIREMENTS='$LAYOUT_FILES_REQUIREMENTS'"
+  echo "LAYOUT_FILES_DESIGN='$LAYOUT_FILES_DESIGN'"
+  echo "LAYOUT_FILES_TASKS='$LAYOUT_FILES_TASKS'"
+  echo "LAYOUT_FILES_RESEARCH='$LAYOUT_FILES_RESEARCH'"
+  echo "LAYOUT_FILES_QUICKSTART='$LAYOUT_FILES_QUICKSTART'"
+  echo "LAYOUT_FILES_TRACEABILITY_INDEX='$LAYOUT_FILES_TRACEABILITY_INDEX'"
+  echo "LAYOUT_FILES_CONTRACTS_DIR='$LAYOUT_FILES_CONTRACTS_DIR'"
+  echo "LAYOUT_FILES_PROGRESS_LOG='$LAYOUT_FILES_PROGRESS_LOG'"
+  echo "LAYOUT_FILES_PARKING_LOT='$LAYOUT_FILES_PARKING_LOT'"
+  echo "LAYOUT_FILES_INDEX='$LAYOUT_FILES_INDEX'"
+  echo "LAYOUT_COMPAT_WRITE_STUB_SPEC='$LAYOUT_COMPAT_WRITE_STUB_SPEC'"
+  echo "LAYOUT_COMPAT_STUB_NAME='$LAYOUT_COMPAT_STUB_NAME'"
+  echo "LAYOUT_CATALOG_PATH='$LAYOUT_CATALOG_PATH'"
+}
+
+if $JSON_MODE; then
+  # Not used currently; keeping plain env format for simplicity
+  :
+fi
+
+emit
+

--- a/scripts/bash/resolve-template.sh
+++ b/scripts/bash/resolve-template.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Resolve a template path with optional JSON output.
+# Usage: resolve-template.sh [--json] <key>
+#   key: spec | plan | tasks | pprd | <custom>
+# Behavior:
+#   - Prefer assets override at .specs/.specify/templates/assets/<key>-template.md (case-insensitive)
+#   - Fallback to .specs/.specify/templates/<key>-template.md
+# Output:
+#   - JSON: {"TEMPLATE_PATH":"/abs/path"}
+#   - Plain: /abs/path
+
+JSON_MODE=false
+KEY=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --json) JSON_MODE=true ;;
+    --help|-h)
+      echo "Usage: $0 [--json] <key>"; exit 0 ;;
+    *) KEY="$arg" ;;
+  esac
+done
+
+if [[ -z "$KEY" ]]; then
+  echo "Error: missing <key>. Usage: $0 [--json] <key>" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+REPO_ROOT="$(get_repo_root)"
+TEMPLATES_DIR="$REPO_ROOT/.specs/.specify/templates"
+ASSETS_DIR="$TEMPLATES_DIR/assets"
+
+# Try assets override (case-insensitive match)
+ASSET_CANDIDATE=""
+if [[ -d "$ASSETS_DIR" ]]; then
+  ASSET_CANDIDATE=$(find "$ASSETS_DIR" -maxdepth 1 -type f -iname "${KEY}-template.md" -print -quit || true)
+fi
+
+if [[ -n "$ASSET_CANDIDATE" ]]; then
+  PATH_OUT="$ASSET_CANDIDATE"
+else
+  # Fallback to default location
+  DEFAULT_PATH="$TEMPLATES_DIR/${KEY}-template.md"
+  if [[ -f "$DEFAULT_PATH" ]]; then
+    PATH_OUT="$DEFAULT_PATH"
+  else
+    echo "Error: No template found for key '$KEY'. Looked for: $ASSETS_DIR/[${KEY}-template.md] and $DEFAULT_PATH" >&2
+    exit 1
+  fi
+fi
+
+if $JSON_MODE; then
+  printf '{"TEMPLATE_PATH":"%s"}\n' "$PATH_OUT"
+else
+  printf '%s\n' "$PATH_OUT"
+fi
+

--- a/scripts/bash/setup-plan.sh
+++ b/scripts/bash/setup-plan.sh
@@ -37,12 +37,18 @@ check_feature_branch "$CURRENT_BRANCH" "$HAS_GIT" || exit 1
 mkdir -p "$FEATURE_DIR"
 
 # Copy plan template if it exists
-TEMPLATE="$REPO_ROOT/.specs/.specify/templates/plan-template.md"
-if [[ -f "$TEMPLATE" ]]; then
-    cp "$TEMPLATE" "$IMPL_PLAN"
+# Resolve template path via resolver (assets override if present)
+RESOLVED_TEMPLATE="$REPO_ROOT/.specs/.specify/templates/plan-template.md"
+if [[ -x "$SCRIPT_DIR/resolve-template.sh" ]]; then
+    if RES_JSON="$($SCRIPT_DIR/resolve-template.sh --json plan 2>/dev/null)"; then
+        RESOLVED_TEMPLATE="$(printf '%s' "$RES_JSON" | sed -n 's/.*"TEMPLATE_PATH":"\([^"]*\)".*/\1/p')"
+    fi
+fi
+if [[ -f "$RESOLVED_TEMPLATE" ]]; then
+    cp "$RESOLVED_TEMPLATE" "$IMPL_PLAN"
     echo "Copied plan template to $IMPL_PLAN"
 else
-    echo "Warning: Plan template not found at $TEMPLATE"
+    echo "Warning: Plan template not found at $RESOLVED_TEMPLATE"
     # Create a basic plan file if template doesn't exist
     touch "$IMPL_PLAN"
 fi

--- a/scripts/bash/spec-root.sh
+++ b/scripts/bash/spec-root.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Prints the absolute path of the chosen specs root.
+# Strategy: use read-layout.sh to get LAYOUT_SPEC_ROOTS (csv). Return first existing.
+# If none exists, create the first listed and return it.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+REPO_ROOT="$(get_repo_root)"
+
+if [[ -x "$SCRIPT_DIR/read-layout.sh" ]]; then
+  eval "$($SCRIPT_DIR/read-layout.sh)"
+fi
+
+IFS=',' read -r -a ROOTS <<< "${LAYOUT_SPEC_ROOTS:-specs,.specs/.specify/specs}"
+
+chosen=""
+for r in "${ROOTS[@]}"; do
+  cand="$REPO_ROOT/$r"
+  if [[ -d "$cand" ]]; then chosen="$cand"; break; fi
+done
+
+if [[ -z "$chosen" ]]; then
+  chosen="$REPO_ROOT/${ROOTS[0]}"
+  mkdir -p "$chosen"
+fi
+
+printf '%s\n' "$chosen"
+

--- a/scripts/powershell/check-prerequisites.ps1
+++ b/scripts/powershell/check-prerequisites.ps1
@@ -93,7 +93,8 @@ if (-not (Test-Path $paths.FEATURE_DIR -PathType Container)) {
 }
 
 if (-not (Test-Path $paths.IMPL_PLAN -PathType Leaf)) {
-    Write-Output "ERROR: plan.md not found in $($paths.FEATURE_DIR)"
+    $planName = [IO.Path]::GetFileName($paths.IMPL_PLAN)
+    Write-Output "ERROR: $planName not found in $($paths.FEATURE_DIR)"
     Write-Output "Run /plan first to create the implementation plan."
     exit 1
 }

--- a/scripts/powershell/read-layout.ps1
+++ b/scripts/powershell/read-layout.ps1
@@ -1,0 +1,65 @@
+#!/usr/bin/env pwsh
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+. "$PSScriptRoot/common.ps1"
+$repoRoot = Get-RepoRoot
+$cfgPath = Join-Path $repoRoot '.specs/.specify/layout.yaml'
+
+# Defaults
+$cfg = [ordered]@{
+  VERSION = 1
+  SPEC_ROOTS = @('specs', '.specs/.specify/specs')
+  FOLDER_STRATEGY = 'epic'
+  FILES = [ordered]@{
+    FPRD='fprd.md'; PPRD='pprd.md'; REQUIREMENTS='requirements.md'; DESIGN='design.md'; TASKS='tasks.md'; RESEARCH='research.md'; QUICKSTART='quickstart.md'; TRACEABILITY_INDEX='traceability_index.md'; CONTRACTS_DIR='contracts'; PROGRESS_LOG='progress_log.md'; PARKING_LOT='parking_lot.md'; INDEX='index.yaml'
+  }
+  COMPAT = [ordered]@{ WRITE_STUB_SPEC=$true; STUB_NAME='spec.md' }
+  CATALOG_PATH = 'specs/catalog.yaml'
+}
+
+if (Test-Path $cfgPath) {
+  $section = ''
+  Get-Content -LiteralPath $cfgPath | ForEach-Object {
+    $line = ($_ -replace '#.*$','').TrimEnd()
+    if (-not $line.Trim()) { return }
+    if ($line -match '^version:\s*(\d+)') { $cfg.VERSION = [int]$matches[1]; return }
+    if ($line -match '^spec_roots:') { $section = 'spec_roots'; return }
+    if ($line -match '^files:') { $section = 'files'; return }
+    if ($line -match '^compat:') { $section = 'compat'; return }
+    if ($line -match '^catalog:') { $section = 'catalog'; return }
+    if ($line -match '^folder_strategy:\s*"?([A-Za-z0-9_-]+)"?') { $cfg.FOLDER_STRATEGY = $matches[1]; return }
+
+    switch ($section) {
+      'spec_roots' {
+        if ($line -match '^-\s*"?([^"']+)"?') { $cfg.SPEC_ROOTS += $matches[1] }
+      }
+      'files' {
+        if ($line -match 'fprd:\s*"?([^"']+)"?') { $cfg.FILES.FPRD = $matches[1] }
+        if ($line -match 'pprd:\s*"?([^"']+)"?') { $cfg.FILES.PPRD = $matches[1] }
+        if ($line -match 'requirements:\s*"?([^"']+)"?') { $cfg.FILES.REQUIREMENTS = $matches[1] }
+        if ($line -match 'design:\s*"?([^"']+)"?') { $cfg.FILES.DESIGN = $matches[1] }
+        if ($line -match 'tasks:\s*"?([^"']+)"?') { $cfg.FILES.TASKS = $matches[1] }
+        if ($line -match 'research:\s*"?([^"']+)"?') { $cfg.FILES.RESEARCH = $matches[1] }
+        if ($line -match 'quickstart:\s*"?([^"']+)"?') { $cfg.FILES.QUICKSTART = $matches[1] }
+        if ($line -match 'traceability_index:\s*"?([^"']+)"?') { $cfg.FILES.TRACEABILITY_INDEX = $matches[1] }
+        if ($line -match 'contracts_dir:\s*"?([^"']+)"?') { $cfg.FILES.CONTRACTS_DIR = $matches[1] }
+        if ($line -match 'progress_log:\s*"?([^"']+)"?') { $cfg.FILES.PROGRESS_LOG = $matches[1] }
+        if ($line -match 'parking_lot:\s*"?([^"']+)"?') { $cfg.FILES.PARKING_LOT = $matches[1] }
+        if ($line -match 'index:\s*"?([^"']+)"?') { $cfg.FILES.INDEX = $matches[1] }
+      }
+      'compat' {
+        if ($line -match 'write_redirect_stub_spec_md:\s*(true|false)') { $cfg.COMPAT.WRITE_STUB_SPEC = ($matches[1] -eq 'true') }
+        if ($line -match 'stub_name:\s*"?([^"']+)"?') { $cfg.COMPAT.STUB_NAME = $matches[1] }
+      }
+      'catalog' {
+        if ($line -match 'path:\s*"?([^"']+)"?') { $cfg.CATALOG_PATH = $matches[1] }
+      }
+    }
+  }
+}
+
+$cfg
+

--- a/scripts/powershell/resolve-template.ps1
+++ b/scripts/powershell/resolve-template.ps1
@@ -1,0 +1,38 @@
+#!/usr/bin/env pwsh
+[CmdletBinding()]
+param(
+  [switch]$Json,
+  [Parameter(Mandatory=$true, Position=0)]
+  [string]$Key
+)
+
+$ErrorActionPreference = 'Stop'
+
+. "$PSScriptRoot/common.ps1"
+$paths = Get-FeaturePathsEnv  # Provides REPO_ROOT; does not require feature branch
+
+$templatesDir = Join-Path $paths.REPO_ROOT '.specs/.specify/templates'
+$assetsDir = Join-Path $templatesDir 'assets'
+
+$resolved = $null
+if (Test-Path $assetsDir) {
+  $needle = "$Key-template.md"
+  $match = Get-ChildItem -Path $assetsDir -File | Where-Object { $_.Name -ieq $needle } | Select-Object -First 1
+  if ($match) { $resolved = $match.FullName }
+}
+
+if (-not $resolved) {
+  $fallback = Join-Path $templatesDir "$Key-template.md"
+  if (Test-Path $fallback) {
+    $resolved = $fallback
+  } else {
+    Write-Error "No template found for key '$Key'. Looked for assets/$Key-template.md and $fallback"
+  }
+}
+
+if ($Json) {
+  [PSCustomObject]@{ TEMPLATE_PATH = $resolved } | ConvertTo-Json -Compress
+} else {
+  Write-Output $resolved
+}
+

--- a/scripts/powershell/spec-root.ps1
+++ b/scripts/powershell/spec-root.ps1
@@ -1,0 +1,25 @@
+#!/usr/bin/env pwsh
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+. "$PSScriptRoot/common.ps1"
+$repo = Get-RepoRoot
+$layout = & (Join-Path $PSScriptRoot 'read-layout.ps1')
+
+$roots = @('specs', '.specs/.specify/specs')
+if ($layout -and $layout.SPEC_ROOTS) { $roots = $layout.SPEC_ROOTS }
+
+$chosen = $null
+foreach ($r in $roots) {
+  $cand = Join-Path $repo $r
+  if (Test-Path $cand -PathType Container) { $chosen = $cand; break }
+}
+if (-not $chosen) {
+  $chosen = Join-Path $repo $roots[0]
+  New-Item -ItemType Directory -Path $chosen -Force | Out-Null
+}
+
+Write-Output $chosen
+

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -64,6 +64,8 @@ def _github_auth_headers(cli_token: str | None = None) -> dict:
     return {"Authorization": f"Bearer {token}"} if token else {}
 
 # Constants
+DEFAULT_TEMPLATE_REPO = "Jrakru/spec-kit"
+
 AI_CHOICES = {
     "copilot": "GitHub Copilot",
     "claude": "Claude Code",
@@ -881,7 +883,7 @@ def init(
     template_repo: Optional[str] = typer.Option(
         None,
         "--template-repo",
-        help="Override template repository in owner/repo form (defaults to github/spec-kit or SPEC_KIT_TEMPLATE_REPO)",
+        help=f"Override template repository in owner/repo form (defaults to {DEFAULT_TEMPLATE_REPO} or SPEC_KIT_TEMPLATE_REPO)",
     ),
     template_path: Optional[Path] = typer.Option(
         None,
@@ -1066,7 +1068,7 @@ def init(
     env_template_repo = os.getenv("SPEC_KIT_TEMPLATE_REPO")
     env_template_path = os.getenv("SPEC_KIT_TEMPLATE_PATH")
 
-    repo_spec = template_repo or env_template_repo or "github/spec-kit"
+    repo_spec = template_repo or env_template_repo or DEFAULT_TEMPLATE_REPO
     try:
         repo_owner, repo_name = repo_spec.split("/", 1)
     except ValueError:

--- a/templates/assets/ADR-template.md
+++ b/templates/assets/ADR-template.md
@@ -1,0 +1,21 @@
+# ADR-<ID>: <Decision Title>
+
+## Status
+- Proposed / Accepted / Superseded (link)
+
+## Context
+- Forces & constraints, why now
+
+## Decision
+- What we chose
+
+## Consequences
+- Positive: <...>
+- Negative: <...>
+
+## Alternatives Considered
+- Option 1: <...>
+- Option 2: <...>
+
+## References
+- Links, issues, prior ADRs

--- a/templates/assets/ChangeRequest-template.md
+++ b/templates/assets/ChangeRequest-template.md
@@ -1,0 +1,23 @@
+# CR-YYYYMMDD-<slug>: <Change Request Title>
+
+## Context
+- What changed & why (trigger, evidence)
+
+## Options Considered
+- A: <...>
+- B: <...>
+- C: <...>
+
+## Impact
+- Outcome delta: <+/- on metric and rationale>
+- Cost/effort delta: <AEP/time/budget>
+- Date delta: <schedule impact>
+- Risk: <tiers & mitigations>
+
+## Decision
+- Approved / Rejected / Defer (owner, date)
+
+## Follow-ups
+- RTM / Roadmap updates
+- Flags / Telemetry changes
+- ADR required? <link or N/A>

--- a/templates/assets/FPRD-template.md
+++ b/templates/assets/FPRD-template.md
@@ -1,0 +1,52 @@
+# FPRD-<ID>: <Feature PRD Title>
+**Linked:** PPRD-<ID>, EP-<ID>
+
+## 1. Problem & Outcome
+- Problem statement: <1–2 paragraphs>
+- Outcome metric(s): <name> — baseline=<x>, target=<y>, measurement window=<w>
+
+## 2. Scope (MoSCoW) & Non-Goals
+- Must: <...>
+- Should: <...>
+- Could: <...>
+- Won’t (this cycle): <...>
+- Non-Goals: <copy from PPRD and add>
+
+## 3. User Stories (SS-###) & Acceptance Criteria (summary)
+- SS-<ID>: <title> — key ACs: <bullets>
+- SS-<ID>: ...
+
+## 4. UX Notes
+- Primary flow(s), empty/error/loading states, accessibility checks
+
+## 5. Technical Notes
+- Data model / schema changes
+- API contracts (I/O schemas, versioning)
+- Dependencies (services, approvals)
+- Performance targets (e.g., p95 latency)
+
+## 6. Tests & Telemetry
+- Tests to add: unit / integration / e2e / contract / data-quality
+- Telemetry events: <names>, schema (fields, types, required), when emitted
+- Dashboard(s): <path or id>, alerts: <thresholds>
+
+## 7. Feature Flags & Rollout
+- Flag name: <product.area.flag_name> (default OFF)
+- Exposure plan: <phased rollout & success/fail gates>
+- Rollback: <how to revert safely>
+
+## 8. Risks & Assumptions
+- <enumerate>
+
+## 9. Definition of Ready (DoR) — must be TRUE before starting
+- [ ] Outcome metric has baseline & target
+- [ ] ACs written for each Story; edge cases captured
+- [ ] Telemetry spec & dashboard stub defined
+- [ ] Flag strategy & rollback documented
+- [ ] Dependencies identified / mocks available
+
+## 10. Definition of Done (DoD)
+- [ ] Tests pass; coverage acceptable
+- [ ] Telemetry events emit and appear in dashboard
+- [ ] Flag default OFF; rollout plan executed or staged
+- [ ] Docs & runbooks updated; RTM row marked Done

--- a/templates/assets/PPRD-template.md
+++ b/templates/assets/PPRD-template.md
@@ -1,0 +1,40 @@
+# PPRD-[ID]: [Portfolio / Product PRD Title]
+
+**Links:** Vision (VIS-###), Strategy (STR-###), Roadmap entry (ROAD-YYYYQX)
+
+## 1. Context & Vision
+- Vision: [2–3 sentences]
+- Problem space / Market: [who, pains, alternatives]
+- Strategic Pillars: [3–5 pillars that move the North Star]
+
+## 2. Outcomes & Targets
+- North Star Metric (NSM): [name] — baseline = [x], target (quarter) = [y]
+- Input metrics (3–5): [name, definition, baseline, target]
+- Guardrails: [latency p95, error rate, defect leakage, etc.]
+
+## 3. Personas & JTBD
+- Persona A — Jobs-to-be-done, pains, motivations
+- Persona B — Jobs-to-be-done, pains, motivations
+
+## 4. Capability Map
+- Level-1 capabilities → Level-2 (boundaries, non-overlap)
+
+## 5. Constraints & Non-Goals
+- SLOs / SLIs (reliability), privacy/legal, accessibility, platform constraints
+- Non-Goals (explicit “won’t do” for this horizon)
+
+## 6. Risks & Unknowns
+- Top 5 risks with mitigations / spikes
+
+## 7. Release Strategy
+- Phasing, feature flags, canary, rollback strategy
+
+## 8. Measurement Plan
+- Telemetry events & schemas to add
+- Dashboards (paths/ids), alerts & thresholds
+
+---
+### Definitions
+- DoR gate for linked FPRDs: [list]
+- DoD gate for FPRDs: [list]
+

--- a/templates/assets/StorySpec-template.md
+++ b/templates/assets/StorySpec-template.md
@@ -1,0 +1,34 @@
+# SS-<ID>: <Story Title>
+**Linked:** FPRD-<ID>, EP-<ID>
+**Outcome contribution:** <how this moves the FPRD outcome>
+**AEP (planned):** <int>
+
+## User Story
+As a <persona>, I want <goal>, so that <value>.
+
+## Acceptance Criteria
+- [ ] AC-1: <Gherkin or bullet>
+- [ ] AC-2: <...>
+
+## Telemetry
+- Events: <names>
+- Schemas: <fields/types/required>
+- When fired: <situations>
+- Dashboard path: <path or id>
+- Guardrails to watch: <latency, error rate, etc.>
+
+## Feature Flag
+- Name: <flag.name> (default OFF)
+- Exposure plan: <phased % and gates>
+- Rollback: <steps>
+
+## Tests
+- Unit: <list>
+- Integration/E2E: <list>
+- Contract/Data-quality (for ETL): <list>
+
+## Dependencies
+- Services, approvals, credentials
+
+## Non-Goals
+- <copied from FPRD + specific exclusions>

--- a/templates/commands/fprds.md
+++ b/templates/commands/fprds.md
@@ -1,0 +1,48 @@
+---
+description: Decompose a PPRD into one or more Feature PRDs (FPRDs) and create feature folders using the repository’s declarative layout.
+scripts:
+  sh: scripts/bash/check-prerequisites.sh --json --paths-only
+  ps: scripts/powershell/check-prerequisites.ps1 -Json -PathsOnly
+---
+
+The user input to you can be provided directly by the agent or as a command argument - you MUST consider it before proceeding with the prompt (if not empty).
+
+User input:
+
+$ARGUMENTS
+
+Goal: From a portfolio/product PRD (PPRD), identify concrete features and create corresponding Feature PRDs (FPRDs) with correct folders/filenames based on the layout configuration. Confirm the feature list with the user before creating files.
+
+Execution steps:
+
+1) Run `{SCRIPT}` from the repository root once and parse `REPO_ROOT` (JSON). All subsequent paths are absolute.
+2) Resolve the FPRD layout template path by running `scripts/bash/resolve-template.sh --json spec` (or PowerShell variant) and reading `TEMPLATE_PATH`.
+3) Determine PPRD source:
+   - If user passed a PPRD path in arguments, use it.
+   - Else search `REPO_ROOT/.specs/.specify/pprd/*.md` for the most recent file.
+   - If none found, ask the user to specify the PPRD path or create one with `/pprd`.
+4) Read the PPRD. Propose a list of 3–7 FPRDs with titles and one‑line scope each. Include optional epic/product attribution if present in PPRD (and surface inferred `SPECIFY_EPIC` / `SPECIFY_PRODUCT` values).
+5) Ask the user to confirm/edit the feature list before creation. Do not create files until the user confirms.
+6) For each confirmed feature (in order):
+   - Compute environment hints from PPRD if possible:
+     * If the PPRD defines a product/epic, set them as `SPECIFY_PRODUCT` and `SPECIFY_EPIC` for this feature creation.
+   - Create the feature folder + branch and seed the FPRD file by running (from REPO_ROOT):
+     - POSIX example: `SPECIFY_PRODUCT="<product>" SPECIFY_EPIC="<epic>" .specs/.specify/scripts/bash/create-new-feature.sh --json "<Feature Title>"`
+     - PowerShell example: `$env:SPECIFY_PRODUCT="<product>"; $env:SPECIFY_EPIC="<epic>"; .specs/.specify/scripts/powershell/create-new-feature.ps1 -Json "<Feature Title>"`
+   - Parse JSON: `BRANCH_NAME`, `SPEC_FILE`.
+   - Load the FPRD layout (from `TEMPLATE_PATH`). Populate the new FPRD file (SPEC_FILE) using the PPRD as upstream context:
+     * Bring forward relevant Personas/JTBD, guardrails, and constraints.
+     * Write a concise “Context & Goals” preface linking back to the PPRD.
+     * Draft initial User Scenarios and Functional Requirements at feature level.
+     * Mark ambiguities in the FPRD with `[NEEDS CLARIFICATION: ...]` to be resolved later via `/clarify`.
+   - Save SPEC_FILE atomically after writing.
+7) Output a summary table with: Feature Title, Branch, SPEC_FILE path.
+8) Recommend next steps: run `/clarify` on each feature, then `/plan` and `/tasks`.
+
+Behavior rules:
+- Never overwrite an existing SPEC_FILE; if it exists with non‑empty content, append a minimal header noting linkage and skip template re‑seeding.
+- Keep the PPRD unchanged; this command only creates FPRDs.
+- For layout routing (flat/epic/product), rely on environment variables set per feature as described above; do not write layout files.
+
+Context for feature decomposition: {ARGS}
+

--- a/templates/commands/plan.md
+++ b/templates/commands/plan.md
@@ -24,7 +24,8 @@ Given the implementation details provided as an argument, do this:
 3. Read the constitution at `/.specs/.specify/memory/constitution.md` to understand constitutional requirements.
 
 4. Execute the implementation plan template:
-   - Load `/.specs/.specify/templates/plan-template.md` (already copied to IMPL_PLAN path)
+   - The setup script has copied the resolved plan layout into IMPL_PLAN using the template resolver (assets override if present)
+   - Load IMPL_PLAN
    - Set Input path to FEATURE_SPEC
    - Run the Execution Flow (main) function steps 1-9
    - The template is self-contained and executable

--- a/templates/commands/pprd-clarify.md
+++ b/templates/commands/pprd-clarify.md
@@ -1,0 +1,47 @@
+---
+description: Identify underspecified areas in a PPRD and record clarifications back into the same PPRD file.
+scripts:
+  sh: scripts/bash/check-prerequisites.sh --json --paths-only
+  ps: scripts/powershell/check-prerequisites.ps1 -Json -PathsOnly
+---
+
+The user input to you can be provided directly by the agent or as a command argument - you MUST consider it before proceeding with the prompt (if not empty).
+
+User input:
+
+$ARGUMENTS
+
+Goal: Clarify a portfolio/product PRD (PPRD). Ask up to 5 targeted questions that materially de-risk subsequent feature decomposition, then write the accepted answers into the PPRD under a Clarifications section and apply updates to relevant sections.
+
+Execution steps:
+
+1) Run `{SCRIPT}` from repo root once and parse JSON for `REPO_ROOT`.
+2) Determine the target PPRD file path:
+   - If the user provided a path in arguments, use it.
+   - Otherwise, resolve specs root via `scripts/bash/spec-root.sh` (or PowerShell) and assume single-file convention: `<SPEC_ROOT>/pprd.md` (or the file name in `files.pprd` from `.specs/.specify/layout.yaml`), if it exists.
+   - If single-file not found, search `<SPEC_ROOT>/pprd/*.md` and pick the most recent.
+   - If still ambiguous, ask the user to select the PPRD path.
+3) Load the PPRD and perform a structured scan for ambiguity using this taxonomy:
+   - Context & Vision; Outcomes & Targets (NSM, input metrics, guardrails)
+   - Personas & JTBD; Capability Map; Constraints & Non-Goals
+   - Risks & Unknowns; Release Strategy; Measurement Plan (events, dashboards, alerts)
+4) Generate a prioritized queue (max 5) of high‑impact clarification questions. Constraints:
+   - Each question answerable via 2–5 options OR a short answer (<=5 words).
+   - Only include questions that change feature decomposition, acceptance criteria, or operational readiness.
+5) Ask EXACTLY ONE question at a time. After each accepted answer:
+   - Ensure a `## Clarifications` heading exists (and a `### Session YYYY-MM-DD` subheading for today).
+   - Append `- Q: <question> → A: <answer>` under the session.
+   - Apply the clarification to the most appropriate section(s) in the PPRD: e.g., metrics, personas, guardrails, constraints.
+   - Save the PPRD file atomically.
+6) Validation after each write and final pass:
+   - Max 5 questions. No duplicates. No unresolved placeholders the answer was meant to remove.
+   - Remove contradictory earlier statements when clarified.
+   - Maintain heading structure and formatting.
+7) Report summary: questions asked/answered, path to updated PPRD, sections touched, and a compact coverage map (Resolved/Deferred/Clear/Outstanding).
+
+Behavior rules:
+- Stop early if adequate coverage exists; recommend proceeding to feature decomposition (see `/fprds`).
+- If the PPRD path is not found, ask the user to provide it; do not create a new PPRD here.
+- Keep questions high‑signal and balanced across unresolved categories.
+
+Context for prioritization: {ARGS}

--- a/templates/commands/pprd.md
+++ b/templates/commands/pprd.md
@@ -1,0 +1,46 @@
+---
+description: Generate a Portfolio/Product PRD (PPRD) Markdown document using the PPRD template.
+scripts:
+  sh: scripts/bash/check-prerequisites.sh --json --paths-only
+  ps: scripts/powershell/check-prerequisites.ps1 -Json -PathsOnly
+---
+
+The user input to you can be provided directly by the agent or as a command argument - you MUST consider it before proceeding with the prompt (if not empty).
+
+User input:
+
+$ARGUMENTS
+
+Goal: Create a new PPRD file by resolving the layout template (assets override if present) and saving it at the canonical specs root defined by the layout. Prefer a single file named per `files.pprd` (e.g., `specs/pprd.md`) unless the repository uses a multi-PPRD convention.
+
+Execution steps:
+
+1. Run `{SCRIPT}` from the repository root ONCE and parse its JSON for `REPO_ROOT`. All subsequent paths are absolute.
+2. Determine the canonical specs root: run `scripts/bash/spec-root.sh` (or PowerShell variant) and capture its absolute output as `SPEC_ROOT`.
+3. Resolve the PPRD layout: run `scripts/bash/resolve-template.sh --json pprd` (or PowerShell) and parse `TEMPLATE_PATH`.
+4. Load the layout from `TEMPLATE_PATH`.
+5. Parse the user input to extract fields:
+   - Required: `PPRD_ID` (e.g., `001`, `2025Q1-01`) and `TITLE` (short, human-readable).
+   - Optional links: `VIS` (e.g., `VIS-123`), `STR` (e.g., `STR-42`), `ROAD` (e.g., `ROAD-2025Q1`).
+   - Flexible parsing rules:
+     * Accept formats like: `ID=123 Title=Payments Revamp VIS=VIS-10 STR=STR-7 ROAD=ROAD-2025Q1`
+     * Or quoted: `ID="123" Title="Payments Revamp"`
+     * Or a simple line: `<ID>: <Title>`
+   - If `PPRD_ID` or `TITLE` cannot be determined from input, STOP and ask the user to provide the missing value(s) succinctly.
+6. Read the layout file name for PPRD (`files.pprd` in `.specs/.specify/layout.yaml`) if present. Otherwise default to `pprd.md`.
+7. Compute `PPRD_PATH`:
+   - Single-file convention: `PPRD_PATH = SPEC_ROOT + '/' + files.pprd` (preferred for most repositories)
+   - Multi-PPRD convention (only if explicitly chosen by the user): derive a slug and place under `SPEC_ROOT/pprd/` with a disambiguating file name.
+8. Populate the template:
+   - Replace the heading line `# PPRD-[ID]: [Portfolio / Product PRD Title]` with `# PPRD-<PPRD_ID>: <TITLE>`.
+   - Replace the **Links** line with available values: `**Links:** Vision (VIS-###), Strategy (STR-###), Roadmap entry (ROAD-YYYYQX)` -> `**Links:** Vision (<VIS or N/A>), Strategy (<STR or N/A>), Roadmap entry (<ROAD or N/A>)`.
+   - Leave the remaining sections intact as structured prompts to be filled by the product team.
+9. Write the completed document to `PPRD_PATH` (create directories as needed). If the file already exists and is non-empty, do not overwrite; append a minimal header noting the attempted creation and exit.
+10. Output a short report including: `PPRD_ID`, `TITLE`, `PPRD_PATH`.
+
+Notes:
+- PPRD documents are portfolio/product-level; they are not tied to a feature branch. Do NOT modify feature spec files or branch state.
+- Always use absolute paths in file operations to avoid context issues.
+- If links are omitted, insert `N/A` placeholders to make the document valid and easy to update later.
+
+Context for PPRD creation: {ARGS}

--- a/templates/commands/specify.md
+++ b/templates/commands/specify.md
@@ -17,7 +17,7 @@ Given that feature description, do this:
 
 1. Run the script `{SCRIPT}` from repo root and parse its JSON output for BRANCH_NAME and SPEC_FILE. All file paths must be absolute.
   **IMPORTANT** You must only ever run this script once. The JSON is provided in the terminal as output - always refer to it to get the actual content you're looking for.
-2. Load `templates/spec-template.md` to understand required sections.
+2. Resolve the spec layout template path by running `scripts/bash/resolve-template.sh --json spec` (or PowerShell variant) and load the resolved `TEMPLATE_PATH` to understand required sections.
 3. Write the specification to SPEC_FILE using the template structure, replacing placeholders with concrete details derived from the feature description (arguments) while preserving section order and headings.
 4. Report completion with branch name, spec file path, and readiness for the next phase.
 

--- a/templates/commands/tasks.md
+++ b/templates/commands/tasks.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 1. Run `{SCRIPT}` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute.
 2. Load and analyze available design documents:
-   - Always read plan.md for tech stack and libraries
+   - Always read design.md for tech stack and libraries
    - IF EXISTS: Read data-model.md for entities
    - IF EXISTS: Read contracts/ for API endpoints
    - IF EXISTS: Read research.md for technical decisions
@@ -25,7 +25,7 @@ $ARGUMENTS
    - Generate tasks based on what's available
 
 3. Generate tasks following the template:
-   - Use `/templates/tasks-template.md` as the base
+   - Resolve the tasks layout path by running `scripts/bash/resolve-template.sh --json tasks` (or PowerShell variant) and use the resolved `TEMPLATE_PATH` as the base
    - Replace example tasks with actual tasks based on:
      * **Setup tasks**: Project init, dependencies, linting
      * **Test tasks [P]**: One per contract, one per integration scenario

--- a/templates/layout.yaml
+++ b/templates/layout.yaml
@@ -1,0 +1,39 @@
+version: 1
+
+spec_roots:
+  - "specs"
+  - ".specs/.specify/specs"
+
+folder_strategy: "epic"
+
+files:
+  fprd: "fprd.md"
+  pprd: "pprd.md"
+  requirements: "requirements.md"
+  design: "design.md"
+  tasks: "tasks.md"
+  research: "research.md"
+  quickstart: "quickstart.md"
+  traceability_index: "traceability_index.md"
+  contracts_dir: "contracts"
+  progress_log: "progress_log.md"
+  parking_lot: "parking_lot.md"
+  index: "index.yaml"
+
+compat:
+  write_redirect_stub_spec_md: true
+  stub_name: "spec.md"
+
+id_policy:
+  requirement_prefix: "R"
+  task_prefix: "T"
+  short_ids: true
+
+defaults:
+  lock_files_enabled: true
+  watch_debounce_ms: 300
+  tui_framework_hint: "Textual"
+
+catalog:
+  path: "specs/catalog.yaml"
+

--- a/templates/plan-template.md
+++ b/templates/plan-template.md
@@ -60,7 +60,7 @@ scripts:
 ### Documentation (this feature)
 ```
 .specs/.specify/specs/[###-feature]/
-├── plan.md              # This file (/plan command output)
+├── design.md            # This file (/plan command output)
 ├── research.md          # Phase 0 output (/plan command)
 ├── data-model.md        # Phase 1 output (/plan command)
 ├── quickstart.md        # Phase 1 output (/plan command)

--- a/templates/pprd-template.md
+++ b/templates/pprd-template.md
@@ -1,0 +1,39 @@
+# PPRD-[ID]: [Portfolio / Product PRD Title]
+
+**Links:** Vision (VIS-###), Strategy (STR-###), Roadmap entry (ROAD-YYYYQX)
+
+## 1. Context & Vision
+- Vision: [2–3 sentences]
+- Problem space / Market: [who, pains, alternatives]
+- Strategic Pillars: [3–5 pillars that move the North Star]
+
+## 2. Outcomes & Targets
+- North Star Metric (NSM): [name] — baseline = [x], target (quarter) = [y]
+- Input metrics (3–5): [name, definition, baseline, target]
+- Guardrails: [latency p95, error rate, defect leakage, etc.]
+
+## 3. Personas & JTBD
+- Persona A — Jobs-to-be-done, pains, motivations
+- Persona B — Jobs-to-be-done, pains, motivations
+
+## 4. Capability Map
+- Level-1 capabilities → Level-2 (boundaries, non-overlap)
+
+## 5. Constraints & Non-Goals
+- SLOs / SLIs (reliability), privacy/legal, accessibility, platform constraints
+- Non-Goals (explicit “won’t do” for this horizon)
+
+## 6. Risks & Unknowns
+- Top 5 risks with mitigations / spikes
+
+## 7. Release Strategy
+- Phasing, feature flags, canary, rollback strategy
+
+## 8. Measurement Plan
+- Telemetry events & schemas to add
+- Dashboards (paths/ids), alerts & thresholds
+
+---
+### Definitions
+- DoR gate for linked FPRDs: [list]
+- DoD gate for FPRDs: [list]

--- a/templates/tasks-template.md
+++ b/templates/tasks-template.md
@@ -1,11 +1,11 @@
 # Tasks: [FEATURE NAME]
 
 **Input**: Design documents from `/.specs/.specify/specs/[###-feature-name]/`
-**Prerequisites**: plan.md (required), research.md, data-model.md, contracts/
+**Prerequisites**: design.md (required), research.md, data-model.md, contracts/
 
 ## Execution Flow (main)
 ```
-1. Load plan.md from feature directory
+1. Load design.md from feature directory
    → If not found: ERROR "No implementation plan found"
    → Extract: tech stack, libraries, structure
 2. Load optional design documents:


### PR DESCRIPTION
This PR adds a concise .github/copilot-instructions.md to help AI coding agents be productive immediately in this repository.

Highlights
- Big-picture overview of the repo’s purpose and the CLI deliverable
- How the CLI fits together (args → tool checks → template resolution → extraction → agent files)
- Declarative layout and template override conventions for scaffolded projects
- Developer workflows for running locally with python -m and uv/uvx, and DocFX docs workflow
- Project conventions (entry point, supported agents, env vars, canonical filenames)
- Reusable utilities (paths helpers, StepTracker, tool checks) and script parity guidance
- Quick examples and links back to README.md, AGENTS.md, and docs/local-development.md

Rationale
- Provides targeted guidance for AI agents (and contributors) to reduce ramp-up time
- Captures repo-specific patterns that aren’t obvious from file inspection alone