### PR TITLE
Enable Pages auto-setup for docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
This PR fixes the docs workflow failure on forks by enabling Pages during configure step.\n\n- Add with.enablement: true to actions/configure-pages@v5\n- Keeps permissions minimal (contents:read, pages:write, id-token:write)\n\nAfter merge, docs workflow should build and deploy without requiring manual Pages setup in repo settings.