### PR TITLE
Docs: fix DocFX globs and contribution links

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -8,12 +8,13 @@
         ]
       },
       {
+        "src": "../",
         "files": [
-          "../README.md",
-          "../CONTRIBUTING.md",
-          "../CODE_OF_CONDUCT.md",
-          "../SECURITY.md",
-          "../SUPPORT.md"
+          "README.md",
+          "CONTRIBUTING.md",
+          "CODE_OF_CONDUCT.md",
+          "SECURITY.md",
+          "SUPPORT.md"
         ],
         "dest": "."
       }
@@ -25,8 +26,9 @@
         ]
       },
       {
+        "src": "../",
         "files": [
-          "../media/**"
+          "media/**"
         ],
         "dest": "media"
       }
@@ -62,7 +64,7 @@
       "_enableSearch": true,
       "_disableContribution": false,
       "_gitContribute": {
-        "repo": "https://github.com/github/spec-kit",
+        "repo": "https://github.com/Jrakru/spec-kit",
         "branch": "main"
       }
     }


### PR DESCRIPTION
- Use src for parent directory in docfx.json to include root-level markdown and media without ../ glob warnings\n- Keep resources under media/ mapped correctly\n- Update _gitContribute repo to Jrakru/spec-kit\n\nThis removes the warnings seen in the previous build and makes contribution links accurate.