### PR TITLE
feat(layout): canonical spec root = .specs/specs; package layout.yaml; dynamic Next Steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped CLI version to 0.0.24.
 
+## [0.0.26] - 2025-09-28
+
+### Templates & Packaging
+
+- Set canonical spec root to `.specs/specs` for new projects; retain legacy paths (`.specs/.specify/specs`, `./specs`) as fallbacks.
+- Promote `templates/layout.yaml` into `.specs/.specify/layout.yaml` in release packages so runtime scripts resolve `spec_roots` consistently.
+- Updated template docs/examples to reference `.specs/specs` (plan/tasks templates).
+
+### Notes
+
+- No CLI code changes in this entry; behavior comes via templates + scripts.
+
 ## [0.0.21] - 2025-09-27
 
 ### Changed


### PR DESCRIPTION
This PR consolidates spec storage under .specs/specs for new projects and improves init UX.\n\n- Canonical spec root set to .specs/specs (legacy fallbacks retained)\n- Packages templates/layout.yaml to .specs/.specify/layout.yaml for runtime discovery\n- Updates plan/tasks templates to reference .specs/specs paths\n- Dynamic Next Steps lists all generated commands with descriptions\n\nValidation\n- Built all agent/script archives and validated required files\n- Smoke tested init flows (Copilot, Claude) with local packages