### PR TITLE
Update PPRD slash command instructions for authoring mode

### DIFF
--- a/templates/commands/pprd.md
+++ b/templates/commands/pprd.md
@@ -11,36 +11,55 @@ User input:
 
 {ARGS}
 
-Goal: Create a new PPRD file by resolving the layout template (assets override if present) and saving it at the canonical specs root defined by the layout. Prefer a single file named per `files.pprd` (e.g., `specs/pprd.md`) unless the repository uses a multi-PPRD convention.
+Goal: Create a new Portfolio/Product PRD (PPRD) file by resolving the repository’s declarative layout and (optionally) drafting full content when `MODE=author`. Prefer a single file named per `files.pprd` (e.g., `specs/pprd.md`) unless the repository explicitly opts into a multi-PPRD convention.
 
 Execution steps:
 
 1. Run `{SCRIPT}` from the repository root ONCE and parse its JSON for `REPO_ROOT`. All subsequent paths are absolute.
 2. Determine the canonical specs root: run `scripts/bash/spec-root.sh` (or PowerShell variant) and capture its absolute output as `SPEC_ROOT`.
-3. Resolve the PPRD layout: run `scripts/bash/resolve-template.sh --json pprd` (or PowerShell) and parse `TEMPLATE_PATH`.
-4. Load the layout from `TEMPLATE_PATH`.
-5. Parse the user input to extract fields:
-   - Required: `PPRD_ID` (e.g., `001`, `2025Q1-01`) and `TITLE` (short, human-readable).
-   - Optional links: `VIS` (e.g., `VIS-123`), `STR` (e.g., `STR-42`), `ROAD` (e.g., `ROAD-2025Q1`).
-   - Flexible parsing rules:
-     * Accept formats like: `ID=123 Title=Payments Revamp VIS=VIS-10 STR=STR-7 ROAD=ROAD-2025Q1`
-     * Or quoted: `ID="123" Title="Payments Revamp"`
-     * Or a simple line: `<ID>: <Title>`
-   - If `PPRD_ID` or `TITLE` cannot be determined from input, STOP and ask the user to provide the missing value(s) succinctly.
-6. Read the layout file name for PPRD (`files.pprd` in `.specs/.specify/layout.yaml`) if present. Otherwise default to `pprd.md`.
-7. Compute `PPRD_PATH`:
-   - Single-file convention: `PPRD_PATH = SPEC_ROOT + '/' + files.pprd` (preferred for most repositories)
-   - Multi-PPRD convention (only if explicitly chosen by the user): derive a slug and place under `SPEC_ROOT/pprd/` with a disambiguating file name.
-8. Populate the template:
-   - Replace the heading line `# PPRD-[ID]: [Portfolio / Product PRD Title]` with `# PPRD-<PPRD_ID>: <TITLE>`.
-   - Replace the **Links** line with available values: `**Links:** Vision (VIS-###), Strategy (STR-###), Roadmap entry (ROAD-YYYYQX)` -> `**Links:** Vision (<VIS or N/A>), Strategy (<STR or N/A>), Roadmap entry (<ROAD or N/A>)`.
-   - Leave the remaining sections intact as structured prompts to be filled by the product team.
-9. Write the completed document to `PPRD_PATH` (create directories as needed). If the file already exists and is non-empty, do not overwrite; append a minimal header noting the attempted creation and exit.
-10. Output a short report including: `PPRD_ID`, `TITLE`, `PPRD_PATH`.
+3. Resolve the PPRD layout: run `scripts/bash/resolve-template.sh --json pprd` (or PowerShell) and parse `TEMPLATE_PATH`, then load the template.
+4. Read `.specs/.specify/templates/layout.yaml` (e.g., run `scripts/bash/read-layout.sh` and parse `LAYOUT_FILES_PPRD`) to locate `files.pprd`; default to `pprd.md` when unset.
+5. Parse the user input to extract fields using the `$ARGUMENTS` contract:
+   - Required: `PPRD_ID` (e.g., `001`, `2025Q1-01`) and `TITLE` (short, human readable).
+   - Optional: `VIS`, `STR`, `ROAD`, `MODE`, `BRIEF`, plus section hints (`NSM`, `INPUT_METRICS`, `GUARDRAILS`, `PERSONAS`, `CAPABILITIES`, `CONSTRAINTS`, `NON_GOALS`, `RISKS`, `RELEASE`, `MEASUREMENT`).
+   - Accept key/value, quoted pairs, or `ID: Title` forms.
+   - If `PPRD_ID` or `TITLE` cannot be inferred, STOP and ask the user for succinct values before continuing.
+6. Compute `PPRD_PATH`:
+   - Single-file convention: `PPRD_PATH = SPEC_ROOT + '/' + files.pprd`.
+   - Multi-file convention (only if the user explicitly requests): slugify `<PPRD_ID>-<TITLE>` and place under `SPEC_ROOT/pprd/`.
+   - If the destination exists and is non-empty, append a short header noting the attempted generation and exit without overwriting content.
+7. Populate required boilerplate in all modes:
+   - Replace the heading `# PPRD-[ID]: [Portfolio / Product PRD Title]` with `# PPRD-<PPRD_ID>: <TITLE>`.
+   - Replace the links line with: `**Links:** Vision (<VIS or N/A>), Strategy (<STR or N/A>), Roadmap entry (<ROAD or N/A>)`.
+
+8. If `MODE` is omitted (default scaffold mode):
+   - Write the untouched remainder of the template so humans can complete it later.
+   - Output a summary with `PPRD_ID`, `TITLE`, `PPRD_PATH`, and `"mode":"scaffold"`.
+
+9. If `MODE=author`, follow the AI Authoring Guide to draft every section with substantive content:
+   1. Gather repository signal (best-effort):
+      - Read `product/Roadmap.csv`, `product/ExperimentLedger.csv`, and `telemetry/events-template.yml` when present.
+      - Skim `ssot-templates-solo-founder/docs/` strategy/vision docs and `.specs/.specify/templates/pprd-template.md` for structure.
+   2. Use the BRIEF and section hints to ground content; only emit `TODO:` markers when critical information cannot be inferred responsibly. Each TODO must be specific.
+   3. Draft sections 1–8 per guide:
+      - Context & Vision: 2–3 sentences + 3–5 strategic pillars tied to north-star metrics.
+      - Outcomes & Targets: NSM with baseline/target, 3–5 input metrics with definitions/targets, and 2–3 guardrails with thresholds.
+      - Personas & JTBD: 1–2 personas, each with JTBD, pains, motivations.
+      - Capability Map: 3–7 level-1 capabilities, optionally level-2 examples.
+      - Constraints & Non-Goals: reliability, privacy/compliance, accessibility, platform limits, plus 3–5 explicit non-goals.
+      - Risks & Unknowns: top 5 risks with mitigations/spikes.
+      - Release Strategy: phasing, flags, canary/rollback, environments/migrations.
+      - Measurement Plan: key events/properties (align with telemetry templates), dashboards/IDs, alert thresholds.
+   4. Ensure metrics include numbers (label “proposed” if inferred) and no raw placeholders like `[x]` remain.
+   5. Respect idempotency: if the destination already contains content, prepend a short note about the skipped authoring attempt instead of overwriting.
+   6. After writing, emit a JSON-style status summary with per-section coverage (e.g., drafted vs TODOs).
+
+10. For both modes, create directories as needed and write atomically. Always use absolute paths.
+11. Final output: short report with `PPRD_ID`, `TITLE`, `PPRD_PATH`, selected mode, and section status (for author mode).
 
 Notes:
-- PPRD documents are portfolio/product-level; they are not tied to a feature branch. Do NOT modify feature spec files or branch state.
-- Always use absolute paths in file operations to avoid context issues.
-- If links are omitted, insert `N/A` placeholders to make the document valid and easy to update later.
+- PPRDs are portfolio/product-level assets; do NOT modify feature spec files or Git branches.
+- When required sources are missing, proceed with reasonable defaults and clearly mark assumptions.
+- Preserve existing Clarifications or metadata if re-running in author mode against a pre-existing file.
 
 Context for PPRD creation: {ARGS}


### PR DESCRIPTION
## Summary
- expand the `/pprd` command instructions to honor the declarative layout and optional authoring mode
- document how to parse arguments, resolve template paths, and seed links across both scaffold and author workflows
- outline the authoring workflow steps for generating fully drafted sections using repository context and guardrails

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d9b8cc8898832ab6f64b8a326bffdf